### PR TITLE
Add meta generator. Fixes HEAD requests. Add healthcheck.

### DIFF
--- a/app.go
+++ b/app.go
@@ -53,6 +53,7 @@ func run() error {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Set the message output to the appropriate writer
 			server.LogOutput = cmd.OutOrStdout()
+			server.SetVersion(version)
 
 			// Validate fields to make sure they're correct
 			if err := server.Validate(); err != nil {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -155,6 +155,12 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 	}
 }
 
+// healthCheck is a simple health check endpoint that returns 200 OK
+func (s *Server) healthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
 func httpError(statusCode int, w http.ResponseWriter, format string, args ...any) {
 	w.WriteHeader(statusCode)
 	fmt.Fprintf(w, format, args...)

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -63,25 +63,28 @@ func (s *Server) router() http.Handler {
 	// the prefix is a valid prefix, and including any potential
 	// authentication method
 	routePrefix := path.Join(s.PathPrefix, "*")
-	r.With(basicAuth, jwtAuth).Get(routePrefix, s.showOrRender)
+	r.With(basicAuth, jwtAuth).HandleFunc(routePrefix, s.showOrRender)
 
 	// Create a route for static assets, including
 	// the cache buster randomized string so we can
 	// force reload the assets on each execution
 	assetsPrefix := path.Join(s.PathPrefix, specialPath, s.cacheBuster)
-	r.Get(path.Join(assetsPrefix, "assets", "*"), s.serveAssets(assetsPrefix))
+	r.HandleFunc(path.Join(assetsPrefix, "assets", "*"), s.serveAssets(assetsPrefix))
+
+	// Create a health check endpoint
+	r.HandleFunc(path.Join(s.PathPrefix, specialPath, "health"), s.healthCheck)
 
 	// Handle special path prefix cases
 	if s.PathPrefix != "/" {
 		// If the path prefix is not the root of the server, then we
 		// can preemptively redirect users to the appropriate destination
 		// so they don't see a not found error
-		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, s.PathPrefix, http.StatusFound)
 		})
 
 		// Redirect path prefix without trailing slash to a canonical location
-		r.Get(strings.TrimSuffix(s.PathPrefix, "/"), func(w http.ResponseWriter, r *http.Request) {
+		r.HandleFunc(strings.TrimSuffix(s.PathPrefix, "/"), func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, s.PathPrefix, http.StatusMovedPermanently)
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,10 +37,16 @@ type Server struct {
 	// Internal fields
 	cacheBuster string
 	templates   *template.Template
+	version     string
 }
 
 // IsBasicAuthEnabled returns true if the server has been configured with
 // a username and password
 func (s *Server) IsBasicAuthEnabled() bool {
 	return s.Username != "" && s.Password != ""
+}
+
+// SetVersion sets the server version
+func (s *Server) SetVersion(version string) {
+	s.version = version
 }

--- a/internal/server/template.go
+++ b/internal/server/template.go
@@ -27,6 +27,7 @@ func (s *Server) generateTemplates() (*template.Template, error) {
 		"getIconForFile": getIconForFile,
 		"unsafeHTML":     func(s string) template.HTML { return template.HTML(s) },
 		"default":        dfault,
+		"serverVersion":  func() string { return s.version },
 	}
 
 	wtfs, err := template.New("").Funcs(tplfuncs).ParseFS(walkTemplatesFS, "templates/*")

--- a/internal/server/templates/app.tmpl
+++ b/internal/server/templates/app.tmpl
@@ -4,6 +4,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="generator" content="github.com/patrickdappollonio/http-server {{ serverVersion }}">
+  <meta name="theme-color" content="#3f51b5">
   <title>{{ .PageTitle | default "HTTP File Server" }}</title>
   <link rel="stylesheet" href="{{ assetpath "style.css" }}">
   <link rel="stylesheet" href="{{ assetpath "roboto-font.css" }}">


### PR DESCRIPTION
This PR:

* Adds a `meta generator` tag. This change does not post content anywhere else, and it's there just so open websites can be crawled and we would know usage eventually.
* Fixes the verbs allowed (`GET` and `HEAD`)
* Adds a health check endpoint at `/_/health`. If you're using a path prefix, you need to prefix it before, so for a prefix `/foo/`, the health check endpoint is `/foo/_/health`.