### PR TITLE
Fix redirecting on empty path parameter

### DIFF
--- a/.github/workflows/testing-pull-request.yaml
+++ b/.github/workflows/testing-pull-request.yaml
@@ -23,5 +23,5 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          version: latest
+          version: ~> v2
           args: release --snapshot --skip=publish --clean

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 http-server
 dist/
+_redirections

--- a/internal/redirects/redirect.go
+++ b/internal/redirects/redirect.go
@@ -246,6 +246,10 @@ func pathMatch(pattern, path string, params map[string]string) bool {
 				return false
 			} else {
 				// Regular placeholder
+				if pathSegment == "" {
+					// Do not match empty segments to parameters
+					return false
+				}
 				params[paramName] = pathSegment
 			}
 		} else if patternSegment == pathSegment {

--- a/internal/redirects/redirect_test.go
+++ b/internal/redirects/redirect_test.go
@@ -358,6 +358,15 @@ func TestRedirectionEngine(t *testing.T) {
 			rules:       "/foo:id/foo/* /foo:id/foo temporary",
 			expectError: true,
 		},
+		{
+			name: "path parameter empty - should not redirect",
+			rules: `
+              /docs/:name /docs/:name/overview permanent
+              /docs/:name/ /docs/:name/overview/ permanent`,
+			visitedPath:          "/docs/",
+			expectHittingHandler: true,
+			expectStatusCode:     http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -61,7 +61,11 @@ func (s *Server) PrintStartup() {
 	}
 
 	if !s.DisableRedirects {
-		fmt.Fprintln(s.LogOutput, startupPrefix, "Redirections enabled from:", s.getPathToRedirectionsFile())
+		if s.redirects == nil {
+			fmt.Fprintf(s.LogOutput, "%s Redirections enabled but no redirections found in %q\n", startupPrefix, s.getPathToRedirectionsFile())
+		} else {
+			fmt.Fprintf(s.LogOutput, "%s Redirections enabled from %q (found %d redirections)\n", startupPrefix, s.getPathToRedirectionsFile(), len(s.redirects.Rules))
+		}
 	}
 
 	s.printWarnings()


### PR DESCRIPTION
In some scenarios, the new redirections logic would match on empty and force you to go through with a redirect even if technically there wasn't a match. 

This also improves startup messages to ensure we're correctly capturing the redirections file and how many rules were detected.