### PR TITLE
Enable option to disable directory listing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,24 +52,26 @@ Usage:
   http-server [flags]
 
 Flags:
-      --banner string          markdown text to be rendered at the top of the directory listing page
-      --cors                   enable CORS support by setting the "Access-Control-Allow-Origin" header to "*"
-      --disable-cache-buster   disable the cache buster for assets from the directory listing feature
-      --disable-etag           disable ETag header generation
-      --disable-markdown       disable the markdown rendering feature
-      --ensure-unexpired-jwt   enable time validation for JWT claims "exp" and "nbf"
-      --gzip                   enable gzip compression for supported content-types
-  -h, --help                   help for http-server
-      --hide-links             hide the links to this project's source code
-      --jwt-key string         signing key for JWT authentication
-      --markdown-before-dir    render markdown content before the directory listing
-      --password string        password for basic authentication
-  -d, --path string            path to the directory you want to serve (default "./")
-      --pathprefix string      path prefix for the URL where the server will listen on (default "/")
-  -p, --port int               port to configure the server to listen on (default 5000)
-      --title string           title of the directory listing page
-      --username string        username for basic authentication
-  -v, --version                version for http-server
+      --banner string               markdown text to be rendered at the top of the directory listing page
+      --cors                        enable CORS support by setting the "Access-Control-Allow-Origin" header to "*"
+      --disable-cache-buster        disable the cache buster for assets from the directory listing feature
+      --disable-directory-listing   disable the directory listing feature and return 404s for directories without index
+      --disable-etag                disable ETag header generation
+      --disable-markdown            disable the markdown rendering feature
+      --disable-redirects           disable redirection file handling
+      --ensure-unexpired-jwt        enable time validation for JWT claims "exp" and "nbf"
+      --gzip                        enable gzip compression for supported content-types
+  -h, --help                        help for http-server
+      --hide-links                  hide the links to this project's source code visible in the header and footer
+      --jwt-key string              signing key for JWT authentication
+      --markdown-before-dir         render markdown content before the directory listing
+      --password string             password for basic authentication
+  -d, --path string                 path to the directory you want to serve (default "./")
+      --pathprefix string           path prefix for the URL where the server will listen on (default "/")
+  -p, --port int                    port to configure the server to listen on (default 5000)
+      --title string                title of the directory listing page
+      --username string             username for basic authentication
+  -v, --version                     version for http-server
 ```
 
 ### Detailed configuration

--- a/app.go
+++ b/app.go
@@ -109,6 +109,7 @@ func run() error {
 	flags.BoolVar(&server.ETagDisabled, "disable-etag", false, "disable ETag header generation")
 	flags.BoolVar(&server.GzipEnabled, "gzip", false, "enable gzip compression for supported content-types")
 	flags.BoolVar(&server.DisableRedirects, "disable-redirects", false, "disable redirection file handling")
+	flags.BoolVar(&server.DisableDirectoryList, "disable-directory-listing", false, "disable the directory listing feature and return 404s for directories without index")
 
 	return rootCmd.Execute()
 }

--- a/docs/directory-listing.md
+++ b/docs/directory-listing.md
@@ -10,6 +10,12 @@ An example of what the directory listing page looks like is below:
 
 ![Directory listing](../img/sample-site.png)
 
+### Disabling directory listing
+
+If you want to disable the directory listing feature, you can use the `--disable-directory-listing` option (or one of the available options via environment variables or configuration file). This will prevent the directory listing page from showing up, and instead, the user will see a `404 Not Found` error.
+
+Disabling directory listing also disables the [Markdown rendering feature](#markdown-support), as the Markdown rendering feature is only available when the directory listing feature is enabled.
+
 ### Title change
 
 The page title can be changed with the `--title` option (or one of the available options via environment variables or configuration file). The default value is `HTTP File Server`, but you can change it to whatever you want.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -77,6 +77,13 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
+	// Check if directory listing is disabled, if so,
+	// return here with a 404 error
+	if s.DisableDirectoryList {
+		httpError(http.StatusNotFound, w, "404 not found")
+		return
+	}
+
 	// Open the directory path and read all files
 	dir, err := os.Open(requestedPath)
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ type Server struct {
 	BannerMarkdown       string `flagName:"banner" validate:"omitempty,max=1000"`
 	cachedBannerMarkdown string
 	LogOutput            io.Writer
+	DisableDirectoryList bool
 
 	// Basic auth settings
 	Username string `flagName:"username" validate:"omitempty,alphanum,excluded_with=JWTSigningKey"`

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -16,6 +16,10 @@ func (s *Server) PrintStartup() {
 		fmt.Fprintln(s.LogOutput, startupPrefix, "Path prefix:", s.PathPrefix)
 	}
 
+	if s.DisableDirectoryList {
+		fmt.Fprintln(s.LogOutput, startupPrefix, "Directory listing disabled (including markdown rendering)")
+	}
+
 	if s.GzipEnabled {
 		fmt.Fprintln(s.LogOutput, startupPrefix, "Gzip compression enabled for supported content types")
 	}


### PR DESCRIPTION
Disable directory listing will return a HTTP 404 Not Found status code back to the user. In the future, when https://github.com/patrickdappollonio/http-server/issues/120 is addressed, this can be further improved by customizing the error page.