### PR TITLE
Add support for custom 404 error pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,26 +52,28 @@ Usage:
   http-server [flags]
 
 Flags:
-      --banner string               markdown text to be rendered at the top of the directory listing page
-      --cors                        enable CORS support by setting the "Access-Control-Allow-Origin" header to "*"
-      --disable-cache-buster        disable the cache buster for assets from the directory listing feature
-      --disable-directory-listing   disable the directory listing feature and return 404s for directories without index
-      --disable-etag                disable ETag header generation
-      --disable-markdown            disable the markdown rendering feature
-      --disable-redirects           disable redirection file handling
-      --ensure-unexpired-jwt        enable time validation for JWT claims "exp" and "nbf"
-      --gzip                        enable gzip compression for supported content-types
-  -h, --help                        help for http-server
-      --hide-links                  hide the links to this project's source code visible in the header and footer
-      --jwt-key string              signing key for JWT authentication
-      --markdown-before-dir         render markdown content before the directory listing
-      --password string             password for basic authentication
-  -d, --path string                 path to the directory you want to serve (default "./")
-      --pathprefix string           path prefix for the URL where the server will listen on (default "/")
-  -p, --port int                    port to configure the server to listen on (default 5000)
-      --title string                title of the directory listing page
-      --username string             username for basic authentication
-  -v, --version                     version for http-server
+      --banner string                      markdown text to be rendered at the top of the directory listing page
+      --cors                               enable CORS support by setting the "Access-Control-Allow-Origin" header to "*"
+      --custom-not-found-page string       custom "page not found" to serve
+      --custom-not-found-status-code int   custtom status code for pages not found (default 404)
+      --disable-cache-buster               disable the cache buster for assets from the directory listing feature
+      --disable-directory-listing          disable the directory listing feature and return 404s for directories without index
+      --disable-etag                       disable ETag header generation
+      --disable-markdown                   disable the markdown rendering feature
+      --disable-redirects                  disable redirection file handling
+      --ensure-unexpired-jwt               enable time validation for JWT claims "exp" and "nbf"
+      --gzip                               enable gzip compression for supported content-types
+  -h, --help                               help for http-server
+      --hide-links                         hide the links to this project's source code visible in the header and footer
+      --jwt-key string                     signing key for JWT authentication
+      --markdown-before-dir                render markdown content before the directory listing
+      --password string                    password for basic authentication
+  -d, --path string                        path to the directory you want to serve (default "./")
+      --pathprefix string                  path prefix for the URL where the server will listen on (default "/")
+  -p, --port int                           port to configure the server to listen on (default 5000)
+      --title string                       title of the directory listing page
+      --username string                    username for basic authentication
+  -v, --version                            version for http-server
 ```
 
 ### Detailed configuration

--- a/app.go
+++ b/app.go
@@ -110,7 +110,7 @@ func run() error {
 	flags.BoolVar(&server.GzipEnabled, "gzip", false, "enable gzip compression for supported content-types")
 	flags.BoolVar(&server.DisableRedirects, "disable-redirects", false, "disable redirection file handling")
 	flags.BoolVar(&server.DisableDirectoryList, "disable-directory-listing", false, "disable the directory listing feature and return 404s for directories without index")
-
+	flags.StringVar(&server.CustomNotFound, "custom-not-found-page", "", "custom 404 page to display")
 	return rootCmd.Execute()
 }
 

--- a/app.go
+++ b/app.go
@@ -110,7 +110,8 @@ func run() error {
 	flags.BoolVar(&server.GzipEnabled, "gzip", false, "enable gzip compression for supported content-types")
 	flags.BoolVar(&server.DisableRedirects, "disable-redirects", false, "disable redirection file handling")
 	flags.BoolVar(&server.DisableDirectoryList, "disable-directory-listing", false, "disable the directory listing feature and return 404s for directories without index")
-	flags.StringVar(&server.CustomNotFoundPage, "custom-not-found-page", "", "custom 404 page to display")
+	flags.StringVar(&server.CustomNotFoundPage, "custom-not-found-page", "", "custom \"page not found\" to serve")
+	flags.IntVarP(&server.CustomNotFoundStatusCode, "custom-not-found-status-code", "", 404, "custtom status code for pages not found")
 
 	return rootCmd.Execute()
 }

--- a/app.go
+++ b/app.go
@@ -110,7 +110,8 @@ func run() error {
 	flags.BoolVar(&server.GzipEnabled, "gzip", false, "enable gzip compression for supported content-types")
 	flags.BoolVar(&server.DisableRedirects, "disable-redirects", false, "disable redirection file handling")
 	flags.BoolVar(&server.DisableDirectoryList, "disable-directory-listing", false, "disable the directory listing feature and return 404s for directories without index")
-	flags.StringVar(&server.CustomNotFound, "custom-not-found-page", "", "custom 404 page to display")
+	flags.StringVar(&server.CustomNotFoundPage, "custom-not-found-page", "", "custom 404 page to display")
+
 	return rootCmd.Execute()
 }
 

--- a/app.go
+++ b/app.go
@@ -110,8 +110,8 @@ func run() error {
 	flags.BoolVar(&server.GzipEnabled, "gzip", false, "enable gzip compression for supported content-types")
 	flags.BoolVar(&server.DisableRedirects, "disable-redirects", false, "disable redirection file handling")
 	flags.BoolVar(&server.DisableDirectoryList, "disable-directory-listing", false, "disable the directory listing feature and return 404s for directories without index")
-	flags.StringVar(&server.CustomNotFoundPage, "custom-not-found-page", "", "custom \"page not found\" to serve")
-	flags.IntVarP(&server.CustomNotFoundStatusCode, "custom-not-found-status-code", "", 404, "custtom status code for pages not found")
+	flags.StringVar(&server.CustomNotFoundPage, "custom-404", "", "custom \"page not found\" to serve")
+	flags.IntVar(&server.CustomNotFoundStatusCode, "custom-404-code", 0, "custtom status code for pages not found")
 
 	return rootCmd.Execute()
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -40,7 +40,6 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", currentPath)
 			if s.CustomNotFoundPage != "" {
-				fmt.Fprintf(s.LogOutput, "%s %q -- custom %d \n", r.Method, r.RequestURI, http.StatusNotFound)
 				s.serveFile(s.CustomNotFoundPage, w, r)
 				return
 			}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -40,10 +40,10 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", currentPath)
 			if s.CustomNotFoundPage != "" {
-				s.serveFile(s.CustomNotFoundPage, w, r)
+				s.serveFile(s.CustomNotFoundStatusCode, s.CustomNotFoundPage, w, r)
 				return
 			}
-			httpError(http.StatusNotFound, w, "404 not found")
+			httpError(s.CustomNotFoundStatusCode, w, "404 not found")
 			return
 		}
 
@@ -84,7 +84,7 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 	// Check if directory listing is disabled, if so,
 	// return here with a 404 error
 	if s.DisableDirectoryList {
-		httpError(http.StatusNotFound, w, "404 not found")
+		httpError(s.CustomNotFoundStatusCode, w, "404 not found")
 		return
 	}
 
@@ -94,7 +94,7 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 		// If the directory doesn't exist, render an appropriate message
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", requestedPath)
-			httpError(http.StatusNotFound, w, "404 not found")
+			httpError(s.CustomNotFoundStatusCode, w, "404 not found")
 			return
 		}
 
@@ -189,7 +189,7 @@ func (s *Server) serveFile(statusCode int, location string, w http.ResponseWrite
 	f, err := os.Open(location)
 	if err != nil {
 		if os.IsNotExist(err) {
-			httpError(http.StatusNotFound, w, "404 not found")
+			httpError(s.CustomNotFoundStatusCode, w, "404 not found")
 			return
 		}
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -40,6 +40,7 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", currentPath)
 			if s.CustomNotFoundPage != "" {
+				fmt.Fprintf(s.LogOutput, "%s %q -- custom %d \n", r.Method, r.RequestURI, http.StatusNotFound)
 				s.serveFile(s.CustomNotFoundPage, w, r)
 				return
 			}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -39,6 +39,10 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 		// of the app the full path to the given location
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", currentPath)
+			if s.CustomNotFoundPage != "" {
+				s.serveFile(s.CustomNotFoundPage, w, r)
+				return
+			}
 			httpError(http.StatusNotFound, w, "404 not found")
 			return
 		}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -39,8 +39,16 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 		// of the app the full path to the given location
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", currentPath)
+
+			// Overwrite custom page if one was set
 			if s.CustomNotFoundPage != "" {
-				s.serveFile(s.CustomNotFoundStatusCode, s.CustomNotFoundPage, w, r)
+				// Check if the status code was generated
+				statusCode := s.CustomNotFoundStatusCode
+				if statusCode == 0 {
+					statusCode = http.StatusNotFound
+				}
+
+				s.serveFile(statusCode, s.CustomNotFoundPage, w, r)
 				return
 			}
 			httpError(http.StatusNotFound, w, "404 not found")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -43,7 +43,7 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 				s.serveFile(s.CustomNotFoundStatusCode, s.CustomNotFoundPage, w, r)
 				return
 			}
-			httpError(s.CustomNotFoundStatusCode, w, "404 not found")
+			httpError(http.StatusNotFound, w, "404 not found")
 			return
 		}
 
@@ -84,7 +84,7 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 	// Check if directory listing is disabled, if so,
 	// return here with a 404 error
 	if s.DisableDirectoryList {
-		httpError(s.CustomNotFoundStatusCode, w, "404 not found")
+		httpError(http.StatusNotFound, w, "404 not found")
 		return
 	}
 
@@ -94,7 +94,7 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 		// If the directory doesn't exist, render an appropriate message
 		if os.IsNotExist(err) {
 			s.printWarning("attempted to access non-existent path: %s", requestedPath)
-			httpError(s.CustomNotFoundStatusCode, w, "404 not found")
+			httpError(http.StatusNotFound, w, "404 not found")
 			return
 		}
 
@@ -189,7 +189,7 @@ func (s *Server) serveFile(statusCode int, location string, w http.ResponseWrite
 	f, err := os.Open(location)
 	if err != nil {
 		if os.IsNotExist(err) {
-			httpError(s.CustomNotFoundStatusCode, w, "404 not found")
+			httpError(http.StatusNotFound, w, "404 not found")
 			return
 		}
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -16,12 +16,6 @@ import (
 func (s *Server) router() http.Handler {
 	r := chi.NewRouter()
 
-	if s.CustomNotFoundPage != "" {
-		r.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			s.serveFile(s.CustomNotFoundPage, w, r)
-		}))
-	}
-
 	// Allow logging all request to our custom logger
 	r.Use(mw.LogRequest(s.LogOutput, logFormat, "token"))
 

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 
@@ -15,6 +16,16 @@ import (
 
 func (s *Server) router() http.Handler {
 	r := chi.NewRouter()
+
+	if s.CustomNotFound != "" {
+		r.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			if _, err := os.Stat(s.CustomNotFound); err == nil {
+				s.serveFile(s.CustomNotFound, w, r)
+				return
+			}
+		}))
+	}
 
 	// Allow logging all request to our custom logger
 	r.Use(mw.LogRequest(s.LogOutput, logFormat, "token"))

--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 
@@ -17,13 +16,9 @@ import (
 func (s *Server) router() http.Handler {
 	r := chi.NewRouter()
 
-	if s.CustomNotFound != "" {
+	if s.CustomNotFoundPage != "" {
 		r.NotFound(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-			if _, err := os.Stat(s.CustomNotFound); err == nil {
-				s.serveFile(s.CustomNotFound, w, r)
-				return
-			}
+			s.serveFile(s.CustomNotFoundPage, w, r)
 		}))
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,7 @@ type Server struct {
 	cachedBannerMarkdown string
 	LogOutput            io.Writer
 	DisableDirectoryList bool
-	CustomNotFound       string
+	CustomNotFoundPage   string
 
 	// Basic auth settings
 	Username string `flagName:"username" validate:"omitempty,alphanum,excluded_with=JWTSigningKey"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,7 +20,10 @@ type Server struct {
 	cachedBannerMarkdown string
 	LogOutput            io.Writer
 	DisableDirectoryList bool
-	CustomNotFoundPage   string
+
+	// Custom NOTFOUND setting
+	CustomNotFoundPage       string
+	CustomNotFoundStatusCode int
 
 	// Basic auth settings
 	Username string `flagName:"username" validate:"omitempty,alphanum,excluded_with=JWTSigningKey"`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ type Server struct {
 	cachedBannerMarkdown string
 	LogOutput            io.Writer
 	DisableDirectoryList bool
+	CustomNotFound       string
 
 	// Basic auth settings
 	Username string `flagName:"username" validate:"omitempty,alphanum,excluded_with=JWTSigningKey"`

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"net/http"
 )
 
 const startupPrefix = " >"
@@ -22,6 +23,10 @@ func (s *Server) PrintStartup() {
 
 	if s.CustomNotFoundPage != "" {
 		fmt.Fprintln(s.LogOutput, startupPrefix, "Using custom 404 page:", s.CustomNotFoundPage)
+	}
+
+	if s.CustomNotFoundStatusCode != 0 {
+		fmt.Fprintf(s.LogOutput, "%s Using custom 404 status code: \"%d %s\"\n", startupPrefix, s.CustomNotFoundStatusCode, http.StatusText(s.CustomNotFoundStatusCode))
 	}
 
 	if s.GzipEnabled {

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -20,6 +20,10 @@ func (s *Server) PrintStartup() {
 		fmt.Fprintln(s.LogOutput, startupPrefix, "Directory listing disabled (including markdown rendering)")
 	}
 
+	if s.CustomNotFoundPage != "" {
+		fmt.Fprintln(s.LogOutput, startupPrefix, "Custom 404 page set:", s.CustomNotFoundPage)
+	}
+
 	if s.GzipEnabled {
 		fmt.Fprintln(s.LogOutput, startupPrefix, "Gzip compression enabled for supported content types")
 	}

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -21,7 +21,7 @@ func (s *Server) PrintStartup() {
 	}
 
 	if s.CustomNotFoundPage != "" {
-		fmt.Fprintln(s.LogOutput, startupPrefix, "Custom 404 page set:", s.CustomNotFoundPage)
+		fmt.Fprintln(s.LogOutput, startupPrefix, "Using custom 404 page:", s.CustomNotFoundPage)
 	}
 
 	if s.GzipEnabled {

--- a/internal/server/validation.go
+++ b/internal/server/validation.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 
@@ -27,6 +29,12 @@ func (s *Server) Validate() error {
 	// Attempt to validate the structure, and grab the errors
 	err := valid.Struct(s)
 	valerrs, ok := err.(validator.ValidationErrors)
+
+	if s.CustomNotFoundPage != "" {
+		if _, err := os.Stat(s.CustomNotFoundPage); errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
 
 	// If the error isn't empty, and its type is of ValidationError
 	// we can provide a better error message for its validation process

--- a/internal/server/validation.go
+++ b/internal/server/validation.go
@@ -40,8 +40,8 @@ func (s *Server) Validate() error {
 		}
 	}
 
-	if !(s.CustomNotFoundStatusCode >= 100 && s.CustomNotFoundStatusCode <= 511) {
-		return fmt.Errorf(" invalid custom not found status code: %d", s.CustomNotFoundStatusCode)
+	if s := http.StatusText(s.CustomNotFoundStatusCode); s == "" {
+		return fmt.Errorf("invalid custom not found status code: %d", s.CustomNotFoundStatusCode)
 	}
 
 	// If the error isn't empty, and its type is of ValidationError

--- a/internal/server/validation.go
+++ b/internal/server/validation.go
@@ -35,9 +35,13 @@ func (s *Server) Validate() error {
 			if errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("custom not found file %q does not exist", s.CustomNotFoundPage)
 			}
-			
+
 			return err
 		}
+	}
+
+	if !(s.CustomNotFoundStatusCode >= 100 && s.CustomNotFoundStatusCode <= 511) {
+		return fmt.Errorf(" invalid custom not found status code: %d", s.CustomNotFoundStatusCode)
 	}
 
 	// If the error isn't empty, and its type is of ValidationError

--- a/internal/server/validation.go
+++ b/internal/server/validation.go
@@ -31,7 +31,11 @@ func (s *Server) Validate() error {
 	valerrs, ok := err.(validator.ValidationErrors)
 
 	if s.CustomNotFoundPage != "" {
-		if _, err := os.Stat(s.CustomNotFoundPage); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Stat(s.CustomNotFoundPage); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("custom not found file %q does not exist", s.CustomNotFoundPage)
+			}
+			
 			return err
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/patrickdappollonio/http-server/issues/120. Custom 404 page can be passed with `--custom-not-found-page`