### PR TITLE
Add support for custom status codes in "serveFile".

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -170,17 +170,11 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 type statusCodeHijacker struct {
 	http.ResponseWriter
 	givenStatusCode int
-	body            bytes.Buffer
 }
 
 // WriteHeader captures the status code that would have been sent to the client.
 func (s *statusCodeHijacker) WriteHeader(code int) {
 	s.givenStatusCode = code
-}
-
-// Write captures the body that would have been sent to the client.
-func (s *statusCodeHijacker) Write(b []byte) (int, error) {
-	return s.body.Write(b)
 }
 
 // serveFile serves a file with the appropriate headers, including support
@@ -236,25 +230,16 @@ func (s *Server) serveFile(statusCode int, fp string, w http.ResponseWriter, r *
 		w.Header().Set("Content-Type", ctype)
 	}
 
-	// If the status code is 200, we can serve the content directly,
-	// without hijacking the response writer.
-	if statusCode == http.StatusOK || statusCode == 0 {
-		http.ServeContent(w, r, fi.Name(), fi.ModTime(), f)
-		return
-	}
-
 	// If the status code is not 200, we need to hijack the response writer
 	// to capture the status code that would have been sent.
 	hijacker := &statusCodeHijacker{ResponseWriter: w}
 
-	// Call serve content with the hijacked response writer.
-	http.ServeContent(hijacker, r, fi.Name(), fi.ModTime(), f)
-
-	// Write now the customized status code and the body that would have
-	// been sent to the client without the hijacking. The headers were
-	// not hijacked and were already sent.
+	// Write the status code sent by the caller.
 	w.WriteHeader(statusCode)
-	w.Write(hijacker.body.Bytes())
+
+	// Call serve content with the hijacked response writer, which won't
+	// be able to overwrite the status code.
+	http.ServeContent(hijacker, r, fi.Name(), fi.ModTime(), f)
 }
 
 // healthCheck is a simple health check endpoint that returns 200 OK

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -63,7 +63,7 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If the path is not a directory, then it's a file, so we can render it
-	s.serveFile(http.StatusOK, currentPath, w, r)
+	s.serveFile(0, currentPath, w, r)
 }
 
 func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Request) {
@@ -72,7 +72,7 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 	for _, index := range []string{"index.html", "index.htm"} {
 		indexPath := filepath.Join(requestedPath, index)
 		if _, err := os.Stat(indexPath); err == nil {
-			s.serveFile(http.StatusOK, indexPath, w, r)
+			s.serveFile(0, indexPath, w, r)
 			return
 		}
 	}
@@ -179,9 +179,16 @@ func (s *statusCodeHijacker) WriteHeader(code int) {
 
 // serveFile serves a file with the appropriate headers, including support
 // for ETag and Last-Modified headers, as well as range requests.
-func (s *Server) serveFile(statusCode int, fp string, w http.ResponseWriter, r *http.Request) {
-	f, err := os.Open(fp)
+// If the status code is not 0, the status code provided will be used
+// when serving the file in the given path.
+func (s *Server) serveFile(statusCode int, location string, w http.ResponseWriter, r *http.Request) {
+	f, err := os.Open(location)
 	if err != nil {
+		if os.IsNotExist(err) {
+			httpError(http.StatusNotFound, w, "404 not found")
+			return
+		}
+
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -194,7 +201,7 @@ func (s *Server) serveFile(statusCode int, fp string, w http.ResponseWriter, r *
 	}
 
 	var ctype string
-	if local := getContentTypeForFilename(filepath.Base(fp)); local != "" {
+	if local := getContentTypeForFilename(filepath.Base(location)); local != "" {
 		ctype = local
 	}
 
@@ -230,16 +237,19 @@ func (s *Server) serveFile(statusCode int, fp string, w http.ResponseWriter, r *
 		w.Header().Set("Content-Type", ctype)
 	}
 
-	// If the status code is not 200, we need to hijack the response writer
-	// to capture the status code that would have been sent.
-	hijacker := &statusCodeHijacker{ResponseWriter: w}
+	// Check if the caller changed the status code, if not, simply call
+	// the appropriate handler/
+	if statusCode == 0 {
+		http.ServeContent(w, r, fi.Name(), fi.ModTime(), f)
+		return
+	}
 
 	// Write the status code sent by the caller.
 	w.WriteHeader(statusCode)
 
 	// Call serve content with the hijacked response writer, which won't
 	// be able to overwrite the status code.
-	http.ServeContent(hijacker, r, fi.Name(), fi.ModTime(), f)
+	http.ServeContent(&statusCodeHijacker{ResponseWriter: w}, r, fi.Name(), fi.ModTime(), f)
 }
 
 // healthCheck is a simple health check endpoint that returns 200 OK

--- a/internal/server/startup.go
+++ b/internal/server/startup.go
@@ -65,9 +65,7 @@ func (s *Server) PrintStartup() {
 	}
 
 	if !s.DisableRedirects {
-		if s.redirects == nil {
-			fmt.Fprintf(s.LogOutput, "%s Redirections enabled but no redirections found in %q\n", startupPrefix, s.getPathToRedirectionsFile())
-		} else {
+		if s.redirects != nil {
 			fmt.Fprintf(s.LogOutput, "%s Redirections enabled from %q (found %d redirections)\n", startupPrefix, s.getPathToRedirectionsFile(), len(s.redirects.Rules))
 		}
 	}


### PR DESCRIPTION
Related to #126. We need to be able in the server to configure what status code to use when rendering a custom 404 error page.

This offers no end-user benefit, but allows other maintainers to customize response codes if needed.