### PR TITLE
Add support for appropriate GOMAXPROCS that's aware of Kubernetes limits.

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"go.uber.org/automaxprocs/maxprocs"
 )
 
 const (
@@ -29,6 +30,13 @@ func run() error {
 
 	// Create a logger
 	logger := log.New(os.Stdout, "", log.LstdFlags)
+
+	// Configure max processes
+	undoFn, err := maxprocs.Set()
+	if err != nil {
+		logger.Printf("Unable to set max procs: %s -- will continue without setting them", err)
+		undoFn()
+	}
 
 	// Create a piped reader/writer for logging
 	// then intercept logging statements as they

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/yuin/goldmark v1.7.8
 	go.abhg.dev/goldmark/mermaid v0.5.0
+	go.uber.org/automaxprocs v1.6.0
 )
 
 require (
@@ -33,7 +34,6 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ go.abhg.dev/goldmark/mermaid v0.5.0 h1:mDkykpSPJ+5wCQ8bSXgzJ2KQskjXkI5Ndxz7JYDHW
 go.abhg.dev/goldmark/mermaid v0.5.0/go.mod h1:OCyk2o85TX2drWHH+HRy6bih2yZlUwbbv/R1MMh1YLs=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/multierr v1.9.0 h1:7fIwc/ZtS0q++VgcfqFDxSBZVv/Xo49/SYnDFupUwlI=
 go.uber.org/multierr v1.9.0/go.mod h1:X2jQV1h+kxSjClGpnseKVIxpmcjrj7MNnI0bnlfKTVQ=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=

--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,8 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-
-	_ "go.uber.org/automaxprocs"
 )
 
 func main() {


### PR DESCRIPTION
When `http-server` is run with Kubernetes resource requests/limits, the limits seen by the container are _not_ the same limits set in the `resources:` section. [It's a longstanding issue in the Go community](https://github.com/golang/go/issues/33803) where on a CFS scheduler, Go mistakenly takes the value of the host not the value provided by CFS.

This is a very simple change that imports Uber's `gomaxprocs` package which automatically configures these values if they're running inside container with a CFS scheduler. 