### PR TITLE
Allow forcing the download of specific file extensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,32 +81,33 @@ Usage:
   http-server [flags]
 
 Flags:
-      --banner string               markdown text to be rendered at the top of the directory listing page
-      --cors                        enable CORS support by setting the "Access-Control-Allow-Origin" header to "*"
-      --custom-404 string           custom "page not found" to serve
-      --custom-404-code int         custtom status code for pages not found
-      --custom-css-file string      path within the served files to a custom CSS file
-      --disable-cache-buster        disable the cache buster for assets from the directory listing feature
-      --disable-directory-listing   disable the directory listing feature and return 404s for directories without index
-      --disable-etag                disable etag header generation
-      --disable-markdown            disable the markdown rendering feature
-      --disable-redirects           disable redirection file handling
-      --ensure-unexpired-jwt        enable time validation for JWT claims "exp" and "nbf"
-      --etag-max-size string        maximum size for etag header generation, where bigger size = more memory usage (default "5M")
-      --gzip                        enable gzip compression for supported content-types
-  -h, --help                        help for http-server
-      --hide-files-in-markdown      hide file and directory listing in markdown rendering
-      --hide-links                  hide the links to this project's source code visible in the header and footer
-      --jwt-key string              signing key for JWT authentication
-      --markdown-before-dir         render markdown content before the directory listing
-      --password string             password for basic authentication
-  -d, --path string                 path to the directory you want to serve (default "./")
-      --pathprefix string           path prefix for the URL where the server will listen on (default "/")
-  -p, --port int                    port to configure the server to listen on (default 5000)
-      --render-all-markdown         if enabled, all Markdown files will be rendered using the same rendering as the directory listing READMEs
-      --title string                title of the directory listing page
-      --username string             username for basic authentication
-  -v, --version                     version for http-server
+      --banner string                       markdown text to be rendered at the top of the directory listing page
+      --cors                                enable CORS support by setting the "Access-Control-Allow-Origin" header to "*"
+      --custom-404 string                   custom "page not found" to serve
+      --custom-404-code int                 custtom status code for pages not found
+      --custom-css-file string              path within the served files to a custom CSS file
+      --disable-cache-buster                disable the cache buster for assets from the directory listing feature
+      --disable-directory-listing           disable the directory listing feature and return 404s for directories without index
+      --disable-etag                        disable etag header generation
+      --disable-markdown                    disable the markdown rendering feature
+      --disable-redirects                   disable redirection file handling
+      --ensure-unexpired-jwt                enable time validation for JWT claims "exp" and "nbf"
+      --etag-max-size string                maximum size for etag header generation, where bigger size = more memory usage (default "5M")
+      --force-download-extensions strings   file extensions that should be downloaded instead of displayed in browser
+      --gzip                                enable gzip compression for supported content-types
+  -h, --help                                help for http-server
+      --hide-files-in-markdown              hide file and directory listing in markdown rendering
+      --hide-links                          hide the links to this project's source code visible in the header and footer
+      --jwt-key string                      signing key for JWT authentication
+      --markdown-before-dir                 render markdown content before the directory listing
+      --password string                     password for basic authentication
+  -d, --path string                         path to the directory you want to serve (default "./")
+      --pathprefix string                   path prefix for the URL where the server will listen on (default "/")
+  -p, --port int                            port to configure the server to listen on (default 5000)
+      --render-all-markdown                 if enabled, all Markdown files will be rendered using the same rendering as the directory listing READMEs
+      --title string                        title of the directory listing page
+      --username string                     username for basic authentication
+  -v, --version                             version for http-server
 ```
 
 ### Detailed configuration

--- a/app.go
+++ b/app.go
@@ -126,6 +126,7 @@ func run() error {
 	flags.BoolVar(&srv.HideFilesInMarkdown, "hide-files-in-markdown", false, "hide file and directory listing in markdown rendering")
 	flags.StringVar(&srv.CustomCSS, "custom-css-file", "", "path within the served files to a custom CSS file")
 	flags.BoolVar(&srv.FullMarkdownRender, "render-all-markdown", false, "if enabled, all Markdown files will be rendered using the same rendering as the directory listing READMEs")
+	flags.StringSliceVar(&srv.ForceDownloadExtensions, "force-download-extensions", nil, "file extensions that should be downloaded instead of displayed in browser")
 
 	//nolint:wrapcheck // no need to wrap this error
 	return rootCmd.Execute()

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ This is the documentation for `http-server`, a simple, no-dependencies command-l
 * [Directory listing](directory-listing.md)
 * [Authentication](authentication.md)
 * [Redirections](redirections.md)
+* [Force Download Extensions](force-download.md)

--- a/docs/directory-listing.md
+++ b/docs/directory-listing.md
@@ -54,6 +54,7 @@ When using markdown, consider:
   * Code fences' syntax highlighting is not supported
   * Title anchors are not supported when file highlighting is in use, and viceversa
   * Direct links straight to a Markdown file are not rendered as HTML. Markdown files are only rendered within the directory listing feature.
+  * Markdown files in directory listing mode won't be affected by the `--force-download-extensions` flag since they're rendered as HTML before the file serving logic is applied.
 
 #### Image alignment
 

--- a/docs/force-download.md
+++ b/docs/force-download.md
@@ -1,0 +1,48 @@
+# Force Download Extensions
+
+The `--force-download-extensions` flag allows you to specify file extensions that should always be downloaded when accessed through the server, rather than being displayed in the browser.
+
+## Usage
+
+You can specify multiple extensions in one of these ways:
+
+1. Comma-separated list:
+```bash
+http-server --force-download-extensions jpg,pdf,zip
+```
+
+2. Multiple flag occurrences:
+```bash
+http-server --force-download-extensions jpg --force-download-extensions pdf
+```
+
+3. In a configuration file (.http-server.yaml):
+```yaml
+force-download-extensions:
+  - jpg
+  - pdf
+  - zip
+```
+
+4. As environment variables:
+```bash
+export FILE_SERVER_FORCE_DOWNLOAD_EXTENSIONS=jpg,pdf,zip
+```
+
+## How it works
+
+When a client requests a file with an extension that matches one in the list, the server will add a `Content-Disposition: attachment; filename="filename.ext"` header to the response. This tells the browser to download the file rather than attempting to display it.
+
+This is useful for:
+- Image files that you want users to download instead of view in the browser
+- PDF documents that should be saved locally rather than opened in a browser
+- Media files or any other content you want to force as a download
+
+## Limitations
+
+- **Markdown in directory listing**: When using the directory listing feature, Markdown files (like `README.md`) that are rendered as part of the page won't be affected by this flag, since they're processed before the file serving logic is applied.
+- **Direct markdown links**: However, if a user directly accesses a Markdown file via URL (not through directory listing), the force-download setting will apply if .md/.markdown is in the list of extensions.
+
+## Example
+
+If you configure the server with `--force-download-extensions jpg,png`, any requests to files ending in `.jpg` or `.png` will be downloaded automatically instead of being displayed in the browser.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -296,6 +296,12 @@ func (s *Server) serveFile(statusCode int, location string, w http.ResponseWrite
 		w.Header().Set("Content-Type", contentType)
 	}
 
+	// Check if we should force download this file based on its extension
+	if s.ShouldForceDownload(location) {
+		filename := filepath.Base(location)
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+	}
+
 	// Check if the caller changed the status code, if not, simply call
 	// the appropriate handler/
 	if statusCode == 0 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -113,8 +113,8 @@ func (s *Server) ShouldForceDownload(filename string) bool {
 		return false
 	}
 
-	for _, forceExt := range s.ForceDownloadExtensions {
-		if strings.EqualFold(forceExt, ext) {
+	for _, e := range s.ForceDownloadExtensions {
+		if e := strings.TrimPrefix(e, "."); strings.EqualFold(e, ext) {
 			return true
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"io"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/patrickdappollonio/http-server/internal/redirects"
@@ -65,6 +66,9 @@ type Server struct {
 	forbiddenPrefixes []string
 	forbiddenSuffixes []string
 	forbiddenMatches  []string
+
+	// Force download settings
+	ForceDownloadExtensions []string
 }
 
 // IsBasicAuthEnabled returns true if the server has been configured with
@@ -96,4 +100,24 @@ func (s *Server) getCustomCSSURL() string {
 	}
 
 	return css
+}
+
+// ShouldForceDownload returns true if the given file extension should be force-downloaded.
+func (s *Server) ShouldForceDownload(filename string) bool {
+	if len(s.ForceDownloadExtensions) == 0 {
+		return false
+	}
+
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), ".")
+	if ext == "" {
+		return false
+	}
+
+	for _, forceExt := range s.ForceDownloadExtensions {
+		if strings.ToLower(forceExt) == ext {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,7 +114,7 @@ func (s *Server) ShouldForceDownload(filename string) bool {
 	}
 
 	for _, forceExt := range s.ForceDownloadExtensions {
-		if strings.ToLower(forceExt) == ext {
+		if strings.EqualFold(forceExt, ext) {
 			return true
 		}
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestShouldForceDownload(t *testing.T) {
+	tests := []struct {
+		name       string
+		extensions []string
+		filename   string
+		want       bool
+	}{
+		{
+			name:       "empty extensions list",
+			extensions: []string{},
+			filename:   "test.jpg",
+			want:       false,
+		},
+		{
+			name:       "filename without extension",
+			extensions: []string{"jpg", "pdf"},
+			filename:   "testfile",
+			want:       false,
+		},
+		{
+			name:       "matching extension",
+			extensions: []string{"jpg", "pdf", "zip"},
+			filename:   "test.pdf",
+			want:       true,
+		},
+		{
+			name:       "non-matching extension",
+			extensions: []string{"jpg", "pdf", "zip"},
+			filename:   "test.txt",
+			want:       false,
+		},
+		{
+			name:       "case insensitive match - lowercase in list",
+			extensions: []string{"jpg", "pdf"},
+			filename:   "test.PDF",
+			want:       true,
+		},
+		{
+			name:       "case insensitive match - uppercase in list",
+			extensions: []string{"JPG", "PDF"},
+			filename:   "test.pdf",
+			want:       true,
+		},
+		{
+			name:       "extension with dot",
+			extensions: []string{".jpg", "pdf"},
+			filename:   "test.jpg",
+			want:       true,
+		},
+		{
+			name:       "filename with path",
+			extensions: []string{"jpg", "pdf"},
+			filename:   "/path/to/file/test.jpg",
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{
+				ForceDownloadExtensions: tt.extensions,
+			}
+
+			if got := s.ShouldForceDownload(tt.filename); got != tt.want {
+				t.Errorf("ShouldForceDownload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added support for forcing file downloads via Content-Disposition header. 

This feature allows specifying extensions that should always be downloaded instead of displayed in browser using the new `--force-download-extensions` flag. 

Documentation includes implementation details, usage examples, and limitations regarding markdown rendering.