### PR TITLE
Add custom output formats.

### DIFF
--- a/docs/directory-listing.md
+++ b/docs/directory-listing.md
@@ -10,6 +10,62 @@ An example of what the directory listing page looks like is below:
 
 ![Directory listing](../img/sample-site.png)
 
+### Alternative output formats
+
+By default, directory listings are rendered as HTML pages. However, you can request alternative formats using the `output` query parameter:
+
+* `?output=json` - Returns a JSON representation of the directory contents
+* `?output=terminal` - Returns a terminal-friendly tabular representation of the directory contents
+* `?output=plain-list` - Returns a minimal list of filenames with directories having trailing slashes
+
+For example, to get a JSON listing of a directory:
+```
+GET /example/?output=json
+```
+
+The JSON output includes the current path, parent path, and an array of files with their metadata:
+```json
+{
+  "current_path": "/example/",
+  "parent_path": "/",
+  "files": [
+    {
+      "name": "file.txt",
+      "size": 1024,
+      "is_directory": false,
+      "mod_time": "2023-04-15 10:30:45",
+      "path": "/example/file.txt"
+    },
+    {
+      "name": "subfolder",
+      "size": 0,
+      "is_directory": true,
+      "mod_time": "2023-04-15 09:20:30",
+      "path": "/example/subfolder/"
+    }
+  ]
+}
+```
+
+The terminal output provides a formatted tabular listing suitable for terminal display:
+```
+Current directory: /example/
+Parent directory: /
+
+Type  Name       Size  Modified
+----  ----       ----  --------
+FILE  file.txt   1024  2023-04-15 10:30:45
+DIR   subfolder  0     2023-04-15 09:20:30
+```
+
+The plain-list output provides a minimal list of files and directories:
+```
+file.txt
+subfolder/
+```
+
+If an unsupported format is specified, the server will return a 400 Bad Request error with a message indicating the supported formats.
+
 ### Disabling directory listing
 
 If you want to disable the directory listing feature, you can use the `--disable-directory-listing` option (or one of the available options via environment variables or configuration file). This will prevent the directory listing page from showing up, and instead, the user will see a `404 Not Found` error.

--- a/docs/directory-listing.md
+++ b/docs/directory-listing.md
@@ -58,10 +58,11 @@ FILE  file.txt   1024  2023-04-15 10:30:45
 DIR   subfolder  0     2023-04-15 09:20:30
 ```
 
-The plain-list output provides a minimal list of files and directories:
+The plain-list output provides a minimal list of files and directories, with directories being at the top and having a trailing slash:
+
 ```
-file.txt
 subfolder/
+file.txt
 ```
 
 If an unsupported format is specified, the server will return a 400 Bad Request error with a message indicating the supported formats.

--- a/internal/renderer/json.go
+++ b/internal/renderer/json.go
@@ -26,21 +26,21 @@ type jsonResponse struct {
 	Files       []fileInfo `json:"files"`
 }
 
-// jsonRenderer implements the Renderer interface for JSON output.
-type jsonRenderer struct{}
+// JSONRenderer implements the Renderer interface for JSON output.
+type JSONRenderer struct{}
 
 // NewJSONRenderer creates a new JSON renderer.
-func NewJSONRenderer() *jsonRenderer {
-	return &jsonRenderer{}
+func NewJSONRenderer() *JSONRenderer {
+	return &JSONRenderer{}
 }
 
 // Format returns the format identifier for this renderer.
-func (r *jsonRenderer) Format() string {
+func (r *JSONRenderer) Format() string {
 	return "json"
 }
 
 // Render renders a directory listing in JSON format.
-func (r *jsonRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
+func (r *JSONRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
 	fileList := make([]fileInfo, 0, len(files))
 
 	for _, file := range files {

--- a/internal/renderer/json.go
+++ b/internal/renderer/json.go
@@ -1,0 +1,72 @@
+package renderer
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// fileInfo represents a file's metadata for JSON output.
+type fileInfo struct {
+	Name        string `json:"name"`
+	Size        int64  `json:"size"`
+	IsDirectory bool   `json:"is_directory"`
+	ModTime     string `json:"mod_time"`
+	Path        string `json:"path"`
+}
+
+// jsonResponse represents the JSON response structure.
+type jsonResponse struct {
+	CurrentPath string     `json:"current_path"`
+	ParentPath  string     `json:"parent_path"`
+	Files       []fileInfo `json:"files"`
+}
+
+// jsonRenderer implements the Renderer interface for JSON output.
+type jsonRenderer struct{}
+
+// NewJSONRenderer creates a new JSON renderer.
+func NewJSONRenderer() *jsonRenderer {
+	return &jsonRenderer{}
+}
+
+// Format returns the format identifier for this renderer.
+func (r *jsonRenderer) Format() string {
+	return "json"
+}
+
+// Render renders a directory listing in JSON format.
+func (r *jsonRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
+	fileList := make([]fileInfo, 0, len(files))
+
+	for _, file := range files {
+		filePath := filepath.Join(config.CurrentPath, file.Name())
+		if !strings.HasSuffix(filePath, "/") && file.IsDir() {
+			filePath += "/"
+		}
+
+		fileList = append(fileList, fileInfo{
+			Name:        file.Name(),
+			Size:        file.Size(),
+			IsDirectory: file.IsDir(),
+			ModTime:     file.ModTime().Format(time.RFC3339),
+			Path:        filePath,
+		})
+	}
+
+	response := jsonResponse{
+		CurrentPath: config.CurrentPath,
+		ParentPath:  config.ParentPath,
+		Files:       fileList,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		return fmt.Errorf("encoding JSON response: %w", err)
+	}
+	return nil
+}

--- a/internal/renderer/json_test.go
+++ b/internal/renderer/json_test.go
@@ -1,0 +1,132 @@
+package renderer
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestJSONRenderer_Format(t *testing.T) {
+	renderer := NewJSONRenderer()
+	if renderer.Format() != "json" {
+		t.Errorf("Expected format to be 'json', got %q", renderer.Format())
+	}
+}
+
+func TestJSONRenderer_Render(t *testing.T) {
+	// Create test files
+	fixedTime := time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC)
+	files := []os.FileInfo{
+		mockFileInfo{
+			name:    "file1.txt",
+			size:    100,
+			mode:    0o644,
+			modTime: fixedTime,
+			isDir:   false,
+		},
+		mockFileInfo{
+			name:    "dir1",
+			size:    0,
+			mode:    0o755 | os.ModeDir,
+			modTime: fixedTime,
+			isDir:   true,
+		},
+	}
+
+	// Create config
+	config := Config{
+		CurrentPath: "/path/to/dir",
+		ParentPath:  "/path/to",
+		Logger:      io.Discard,
+	}
+
+	// Create response recorder
+	w := httptest.NewRecorder()
+
+	// Create renderer and render
+	renderer := NewJSONRenderer()
+	err := renderer.Render(config, w, files)
+	// Check no error
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check content type
+	resp := w.Result()
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Expected Content-Type %q, got %q", "application/json", contentType)
+	}
+
+	// Decode response and validate structure
+	var response struct {
+		CurrentPath string `json:"current_path"`
+		ParentPath  string `json:"parent_path"`
+		Files       []struct {
+			Name        string `json:"name"`
+			Size        int64  `json:"size"`
+			IsDirectory bool   `json:"is_directory"`
+			ModTime     string `json:"mod_time"`
+			Path        string `json:"path"`
+		} `json:"files"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		t.Fatalf("Error decoding response JSON: %v", err)
+	}
+
+	// Validate response fields
+	if response.CurrentPath != "/path/to/dir" {
+		t.Errorf("Expected CurrentPath to be %q, got %q", "/path/to/dir", response.CurrentPath)
+	}
+
+	if response.ParentPath != "/path/to" {
+		t.Errorf("Expected ParentPath to be %q, got %q", "/path/to", response.ParentPath)
+	}
+
+	if len(response.Files) != 2 {
+		t.Fatalf("Expected 2 files, got %d", len(response.Files))
+	}
+
+	// Validate first file (regular file)
+	if response.Files[0].Name != "file1.txt" {
+		t.Errorf("Expected file name to be %q, got %q", "file1.txt", response.Files[0].Name)
+	}
+	if response.Files[0].Size != 100 {
+		t.Errorf("Expected file size to be %d, got %d", 100, response.Files[0].Size)
+	}
+	if response.Files[0].IsDirectory {
+		t.Errorf("Expected IsDirectory to be false")
+	}
+	expectedTime := fixedTime.Format(time.RFC3339)
+	if response.Files[0].ModTime != expectedTime {
+		t.Errorf("Expected mod time to be %q, got %q", expectedTime, response.Files[0].ModTime)
+	}
+	// Check path
+	expectedPath := "/path/to/dir/file1.txt"
+	if response.Files[0].Path != expectedPath {
+		t.Errorf("Expected path to be %q, got %q", expectedPath, response.Files[0].Path)
+	}
+
+	// Validate second file (directory)
+	if response.Files[1].Name != "dir1" {
+		t.Errorf("Expected file name to be %q, got %q", "dir1", response.Files[1].Name)
+	}
+	if response.Files[1].Size != 0 {
+		t.Errorf("Expected file size to be %d, got %d", 0, response.Files[1].Size)
+	}
+	if !response.Files[1].IsDirectory {
+		t.Errorf("Expected IsDirectory to be true")
+	}
+	if response.Files[1].ModTime != expectedTime {
+		t.Errorf("Expected mod time to be %q, got %q", expectedTime, response.Files[1].ModTime)
+	}
+	// Check path with trailing slash for directory
+	expectedPath = "/path/to/dir/dir1/"
+	if response.Files[1].Path != expectedPath {
+		t.Errorf("Expected path to be %q, got %q", expectedPath, response.Files[1].Path)
+	}
+}

--- a/internal/renderer/plainlist.go
+++ b/internal/renderer/plainlist.go
@@ -7,21 +7,21 @@ import (
 	"strings"
 )
 
-// plainListRenderer implements the Renderer interface for plain list output.
-type plainListRenderer struct{}
+// PlainListRenderer implements the Renderer interface for plain list output.
+type PlainListRenderer struct{}
 
 // NewPlainListRenderer creates a new plainlist renderer.
-func NewPlainListRenderer() *plainListRenderer {
-	return &plainListRenderer{}
+func NewPlainListRenderer() *PlainListRenderer {
+	return &PlainListRenderer{}
 }
 
 // Format returns the format identifier for this renderer.
-func (r *plainListRenderer) Format() string {
+func (r *PlainListRenderer) Format() string {
 	return "plain-list"
 }
 
 // Render renders a directory listing as a simple list of filenames.
-func (r *plainListRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
+func (r *PlainListRenderer) Render(_ Config, w http.ResponseWriter, files []os.FileInfo) error {
 	var output strings.Builder
 
 	for _, file := range files {

--- a/internal/renderer/plainlist.go
+++ b/internal/renderer/plainlist.go
@@ -1,0 +1,41 @@
+package renderer
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// plainListRenderer implements the Renderer interface for plain list output.
+type plainListRenderer struct{}
+
+// NewPlainListRenderer creates a new plainlist renderer.
+func NewPlainListRenderer() *plainListRenderer {
+	return &plainListRenderer{}
+}
+
+// Format returns the format identifier for this renderer.
+func (r *plainListRenderer) Format() string {
+	return "plain-list"
+}
+
+// Render renders a directory listing as a simple list of filenames.
+func (r *plainListRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
+	var output strings.Builder
+
+	for _, file := range files {
+		name := file.Name()
+		if file.IsDir() {
+			name += "/"
+		}
+		output.WriteString(name + "\n")
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, err := w.Write([]byte(output.String()))
+	if err != nil {
+		return fmt.Errorf("writing plain list output: %w", err)
+	}
+	return nil
+}

--- a/internal/renderer/plainlist_test.go
+++ b/internal/renderer/plainlist_test.go
@@ -1,0 +1,88 @@
+package renderer
+
+import (
+	"io"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlainListRenderer_Format(t *testing.T) {
+	renderer := NewPlainListRenderer()
+	if renderer.Format() != "plain-list" {
+		t.Errorf("Expected format to be 'plain-list', got %q", renderer.Format())
+	}
+}
+
+func TestPlainListRenderer_Render(t *testing.T) {
+	// Create test files
+	fixedTime := time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC)
+	files := []os.FileInfo{
+		mockFileInfo{
+			name:    "file1.txt",
+			size:    100,
+			mode:    0o644,
+			modTime: fixedTime,
+			isDir:   false,
+		},
+		mockFileInfo{
+			name:    "dir1",
+			size:    0,
+			mode:    0o755 | os.ModeDir,
+			modTime: fixedTime,
+			isDir:   true,
+		},
+	}
+
+	// Create config
+	config := Config{
+		CurrentPath: "/path/to/dir",
+		ParentPath:  "/path/to",
+		Logger:      io.Discard,
+	}
+
+	// Create response recorder
+	w := httptest.NewRecorder()
+
+	// Create renderer and render
+	renderer := NewPlainListRenderer()
+	err := renderer.Render(config, w, files)
+	// Check no error
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check content type
+	resp := w.Result()
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "text/plain; charset=utf-8" {
+		t.Errorf("Expected Content-Type %q, got %q", "text/plain; charset=utf-8", contentType)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Error reading response body: %v", err)
+	}
+	output := string(body)
+
+	// Check for expected file entries
+	expectedLines := []string{
+		"file1.txt\n",
+		"dir1/\n",
+	}
+
+	for _, expected := range expectedLines {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Expected output to contain %q, but it did not", expected)
+		}
+	}
+
+	// Verify the exact output (order matters)
+	expectedOutput := "file1.txt\ndir1/\n"
+	if output != expectedOutput {
+		t.Errorf("Expected output:\n%q\nGot:\n%q", expectedOutput, output)
+	}
+}

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -51,7 +51,7 @@ func Render(format string, config Config, w http.ResponseWriter, files []os.File
 		}
 	}
 
-	return UnsupportedFormatError{Format: string(format)}
+	return UnsupportedFormatError{Format: format}
 }
 
 // GetSupportedFormats returns a list of supported formats.
@@ -67,12 +67,7 @@ func GetSupportedFormats() []string {
 
 // GetSupportedFormatsString returns a comma-separated string of supported formats.
 func GetSupportedFormatsString() string {
-	formats := GetSupportedFormats()
-	result := make([]string, len(formats))
-	for i, f := range formats {
-		result[i] = string(f)
-	}
-	return strings.Join(result, ", ")
+	return strings.Join(GetSupportedFormats(), ", ")
 }
 
 // ParseFormat converts a string to a Format, returning

--- a/internal/renderer/renderer.go
+++ b/internal/renderer/renderer.go
@@ -1,0 +1,109 @@
+// Package renderer provides directory listing rendering in various formats.
+package renderer
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Renderer defines the interface for directory listing renderers.
+type Renderer interface {
+	// Format returns the format identifier for this renderer.
+	Format() string
+	// Render renders the directory listing to the response writer.
+	Render(config Config, w http.ResponseWriter, files []os.FileInfo) error
+}
+
+// Config holds the common configuration for renderers.
+type Config struct {
+	// CurrentPath is the current directory path.
+	CurrentPath string
+	// ParentPath is the parent directory path.
+	ParentPath string
+	// Logger is used for logging errors.
+	Logger io.Writer
+}
+
+// renderers is a slice of all available renderers
+var renderers = []Renderer{
+	NewJSONRenderer(),
+	NewTerminalRenderer(),
+	NewPlainListRenderer(),
+}
+
+// Render renders directory listing using the specified format.
+func Render(format string, config Config, w http.ResponseWriter, files []os.FileInfo) error {
+	if format == "html" {
+		return ErrHTMLHandledSeparately
+	}
+
+	for _, r := range renderers {
+		if r.Format() == format {
+			err := r.Render(config, w, files)
+			if err != nil {
+				return fmt.Errorf("rendering with format %s: %w", format, err)
+			}
+			return nil
+		}
+	}
+
+	return UnsupportedFormatError{Format: string(format)}
+}
+
+// GetSupportedFormats returns a list of supported formats.
+func GetSupportedFormats() []string {
+	formats := make([]string, 0, len(renderers))
+	for _, r := range renderers {
+		if r.Format() != "html" {
+			formats = append(formats, r.Format())
+		}
+	}
+	return formats
+}
+
+// GetSupportedFormatsString returns a comma-separated string of supported formats.
+func GetSupportedFormatsString() string {
+	formats := GetSupportedFormats()
+	result := make([]string, len(formats))
+	for i, f := range formats {
+		result[i] = string(f)
+	}
+	return strings.Join(result, ", ")
+}
+
+// ParseFormat converts a string to a Format, returning
+// an error if the format is not supported.
+func ParseFormat(format string) (string, error) {
+	if format == "" {
+		return "html", nil
+	}
+
+	for _, r := range renderers {
+		if r.Format() == format {
+			return format, nil
+		}
+	}
+
+	return "", UnsupportedFormatError{Format: format}
+}
+
+// UnsupportedFormatError is returned when an unsupported format is requested.
+type UnsupportedFormatError struct {
+	Format string
+}
+
+func (e UnsupportedFormatError) Error() string {
+	return "unsupported output format: " + e.Format
+}
+
+func (e UnsupportedFormatError) Is(target error) bool {
+	_, ok := target.(UnsupportedFormatError)
+	return ok
+}
+
+// ErrHTMLHandledSeparately is returned when attempting to create an HTML renderer.
+var ErrHTMLHandledSeparately = errors.New("HTML format is handled separately")

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -1,0 +1,332 @@
+package renderer
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mockFileInfo implements os.FileInfo for testing
+type mockFileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (m mockFileInfo) Name() string       { return m.name }
+func (m mockFileInfo) Size() int64        { return m.size }
+func (m mockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m mockFileInfo) ModTime() time.Time { return m.modTime }
+func (m mockFileInfo) IsDir() bool        { return m.isDir }
+func (m mockFileInfo) Sys() any           { return nil }
+
+func TestGetSupportedFormats(t *testing.T) {
+	formats := GetSupportedFormats()
+
+	// Check that we have the expected formats
+	expectedFormats := []string{"json", "terminal", "plain-list"}
+
+	if len(formats) != len(expectedFormats) {
+		t.Errorf("Expected %d formats, got %d", len(expectedFormats), len(formats))
+	}
+
+	// Check that each expected format is in the list
+	for _, expected := range expectedFormats {
+		found := false
+		for _, actual := range formats {
+			if actual == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected format %q not found in supported formats", expected)
+		}
+	}
+}
+
+func TestGetSupportedFormatsString(t *testing.T) {
+	formatString := GetSupportedFormatsString()
+
+	// This might need to be updated if the supported formats change
+	expectedFormats := []string{"json", "terminal", "plain-list"}
+
+	for _, expected := range expectedFormats {
+		if !strings.Contains(formatString, expected) {
+			t.Errorf("Expected format %q not found in format string %q", expected, formatString)
+		}
+	}
+}
+
+func TestParseFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "empty string defaults to html",
+			input:       "",
+			expected:    "html",
+			expectError: false,
+		},
+		{
+			name:        "json format",
+			input:       "json",
+			expected:    "json",
+			expectError: false,
+		},
+		{
+			name:        "terminal format",
+			input:       "terminal",
+			expected:    "terminal",
+			expectError: false,
+		},
+		{
+			name:        "plain-list format",
+			input:       "plain-list",
+			expected:    "plain-list",
+			expectError: false,
+		},
+		{
+			name:        "unsupported format",
+			input:       "invalid",
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, err := ParseFormat(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for input %q, got nil", tt.input)
+				}
+				var formatErr UnsupportedFormatError
+				if !errors.As(err, &formatErr) {
+					t.Errorf("Expected UnsupportedFormatError, got %T", err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for input %q: %v", tt.input, err)
+				}
+				if format != tt.expected {
+					t.Errorf("Expected format %q, got %q", tt.expected, format)
+				}
+			}
+		})
+	}
+}
+
+func TestRender(t *testing.T) {
+	tests := []struct {
+		name           string
+		format         string
+		expectError    bool
+		expectedStatus int
+		expectedType   string
+	}{
+		{
+			name:           "json format",
+			format:         "json",
+			expectError:    false,
+			expectedStatus: http.StatusOK,
+			expectedType:   "application/json",
+		},
+		{
+			name:           "terminal format",
+			format:         "terminal",
+			expectError:    false,
+			expectedStatus: http.StatusOK,
+			expectedType:   "text/plain; charset=utf-8",
+		},
+		{
+			name:           "plain-list format",
+			format:         "plain-list",
+			expectError:    false,
+			expectedStatus: http.StatusOK,
+			expectedType:   "text/plain; charset=utf-8",
+		},
+		{
+			name:        "html format (handled separately)",
+			format:      "html",
+			expectError: true,
+		},
+		{
+			name:        "invalid format",
+			format:      "invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test files
+			files := []os.FileInfo{
+				mockFileInfo{
+					name:    "file1.txt",
+					size:    100,
+					mode:    0o644,
+					modTime: time.Now(),
+					isDir:   false,
+				},
+				mockFileInfo{
+					name:    "dir1",
+					size:    0,
+					mode:    0o755 | os.ModeDir,
+					modTime: time.Now(),
+					isDir:   true,
+				},
+			}
+
+			// Create config
+			config := Config{
+				CurrentPath: "/path/to/dir",
+				ParentPath:  "/path/to",
+				Logger:      io.Discard,
+			}
+
+			// Create response recorder
+			w := httptest.NewRecorder()
+
+			// Call Render
+			err := Render(tt.format, config, w, files)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for format %q, got nil", tt.format)
+				}
+				if tt.format == "html" && err != ErrHTMLHandledSeparately {
+					t.Errorf("Expected ErrHTMLHandledSeparately, got %v", err)
+				}
+				if tt.format != "html" {
+					var formatErr UnsupportedFormatError
+					if !errors.As(err, &formatErr) {
+						t.Errorf("Expected UnsupportedFormatError, got %T", err)
+					}
+				}
+				return
+			}
+
+			// Check no error
+			if err != nil {
+				t.Errorf("Unexpected error for format %q: %v", tt.format, err)
+				return
+			}
+
+			// Check response status
+			resp := w.Result()
+			if resp.StatusCode != tt.expectedStatus {
+				t.Errorf("Expected status code %d, got %d", tt.expectedStatus, resp.StatusCode)
+			}
+
+			// Check content type
+			contentType := resp.Header.Get("Content-Type")
+			if contentType != tt.expectedType {
+				t.Errorf("Expected Content-Type %q, got %q", tt.expectedType, contentType)
+			}
+		})
+	}
+}
+
+func TestUnsupportedFormatError(t *testing.T) {
+	err := UnsupportedFormatError{Format: "test"}
+
+	// Test Error method
+	if err.Error() != "unsupported output format: test" {
+		t.Errorf("Expected error message %q, got %q", "unsupported output format: test", err.Error())
+	}
+
+	// Test Is method
+	if !errors.Is(err, UnsupportedFormatError{}) {
+		t.Errorf("Expected err to match UnsupportedFormatError")
+	}
+
+	// Test with different error
+	if errors.Is(err, errors.New("some other error")) {
+		t.Errorf("Expected err not to match 'some other error'")
+	}
+}
+
+// Helper function to check if a string contains another string
+func contains(s, substr string) bool {
+	return s == substr ||
+		strings.HasPrefix(s, substr+",") ||
+		strings.HasSuffix(s, ","+substr) ||
+		strings.Contains(s, ","+substr+",")
+}
+
+// errorWriter is a test helper that fails on Write
+type errorWriter struct {
+	http.ResponseWriter
+}
+
+func (w *errorWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("forced write error")
+}
+
+func (w *errorWriter) Header() http.Header {
+	return http.Header{}
+}
+
+func TestRenderErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{
+			name:   "json format",
+			format: "json",
+		},
+		{
+			name:   "terminal format",
+			format: "terminal",
+		},
+		{
+			name:   "plain-list format",
+			format: "plain-list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create minimal test files
+			files := []os.FileInfo{
+				mockFileInfo{
+					name:    "file1.txt",
+					size:    100,
+					modTime: time.Now(),
+					isDir:   false,
+				},
+			}
+
+			// Create config
+			config := Config{
+				CurrentPath: "/path",
+				ParentPath:  "/",
+				Logger:      io.Discard,
+			}
+
+			// Create error response writer
+			w := httptest.NewRecorder()
+			ew := &errorWriter{ResponseWriter: w}
+
+			// Call Render and expect error
+			err := Render(tt.format, config, ew, files)
+			if err == nil {
+				t.Errorf("Expected error for format %q, got nil", tt.format)
+			}
+		})
+	}
+}

--- a/internal/renderer/terminal.go
+++ b/internal/renderer/terminal.go
@@ -1,0 +1,65 @@
+package renderer
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+)
+
+// terminalRenderer implements the Renderer interface for terminal-friendly output.
+type terminalRenderer struct{}
+
+// NewTerminalRenderer creates a new terminal renderer.
+func NewTerminalRenderer() *terminalRenderer {
+	return &terminalRenderer{}
+}
+
+// Format returns the format identifier for this renderer.
+func (r *terminalRenderer) Format() string {
+	return "terminal"
+}
+
+// Render renders a directory listing in terminal-friendly format.
+func (r *terminalRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
+	var buf bytes.Buffer
+	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "Current directory: %s\n", config.CurrentPath)
+	if config.ParentPath != "" {
+		fmt.Fprintf(tw, "Parent directory: %s\n", config.ParentPath)
+	}
+	fmt.Fprintf(tw, "\n")
+
+	// Write headers
+	fmt.Fprintf(tw, "Type\tName\tSize\tModified\n")
+	fmt.Fprintf(tw, "----\t----\t----\t--------\n")
+
+	// Write file data
+	for _, file := range files {
+		fileType := "FILE"
+		if file.IsDir() {
+			fileType = "DIR"
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n",
+			fileType,
+			file.Name(),
+			file.Size(),
+			file.ModTime().Format(time.RFC3339),
+		)
+	}
+
+	if err := tw.Flush(); err != nil {
+		return fmt.Errorf("flushing tabwriter: %w", err)
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, err := w.Write(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("writing terminal output: %w", err)
+	}
+	return nil
+}

--- a/internal/renderer/terminal.go
+++ b/internal/renderer/terminal.go
@@ -9,21 +9,21 @@ import (
 	"time"
 )
 
-// terminalRenderer implements the Renderer interface for terminal-friendly output.
-type terminalRenderer struct{}
+// TerminalRenderer implements the Renderer interface for terminal-friendly output.
+type TerminalRenderer struct{}
 
 // NewTerminalRenderer creates a new terminal renderer.
-func NewTerminalRenderer() *terminalRenderer {
-	return &terminalRenderer{}
+func NewTerminalRenderer() *TerminalRenderer {
+	return &TerminalRenderer{}
 }
 
 // Format returns the format identifier for this renderer.
-func (r *terminalRenderer) Format() string {
+func (r *TerminalRenderer) Format() string {
 	return "terminal"
 }
 
 // Render renders a directory listing in terminal-friendly format.
-func (r *terminalRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
+func (r *TerminalRenderer) Render(config Config, w http.ResponseWriter, files []os.FileInfo) error {
 	var buf bytes.Buffer
 	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
 

--- a/internal/renderer/terminal_test.go
+++ b/internal/renderer/terminal_test.go
@@ -1,0 +1,104 @@
+package renderer
+
+import (
+	"io"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTerminalRenderer_Format(t *testing.T) {
+	renderer := NewTerminalRenderer()
+	if renderer.Format() != "terminal" {
+		t.Errorf("Expected format to be 'terminal', got %q", renderer.Format())
+	}
+}
+
+func TestTerminalRenderer_Render(t *testing.T) {
+	// Create test files
+	fixedTime := time.Date(2023, 1, 2, 3, 4, 5, 0, time.UTC)
+	files := []os.FileInfo{
+		mockFileInfo{
+			name:    "file1.txt",
+			size:    100,
+			mode:    0o644,
+			modTime: fixedTime,
+			isDir:   false,
+		},
+		mockFileInfo{
+			name:    "dir1",
+			size:    0,
+			mode:    0o755 | os.ModeDir,
+			modTime: fixedTime,
+			isDir:   true,
+		},
+	}
+
+	// Create config
+	config := Config{
+		CurrentPath: "/path/to/dir",
+		ParentPath:  "/path/to",
+		Logger:      io.Discard,
+	}
+
+	// Create response recorder
+	w := httptest.NewRecorder()
+
+	// Create renderer and render
+	renderer := NewTerminalRenderer()
+	err := renderer.Render(config, w, files)
+	// Check no error
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Check content type
+	resp := w.Result()
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != "text/plain; charset=utf-8" {
+		t.Errorf("Expected Content-Type %q, got %q", "text/plain; charset=utf-8", contentType)
+	}
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Error reading response body: %v", err)
+	}
+	output := string(body)
+
+	// Check that the output contains the expected information
+	expectedStrings := []string{
+		"Current directory: /path/to/dir",
+		"Parent directory: /path/to",
+		"Type",
+		"Name",
+		"Size",
+		"Modified",
+		"FILE", // For file1.txt
+		"file1.txt",
+		"100", // Size of file1.txt
+		"DIR", // For dir1
+		"dir1",
+		"0", // Size of dir1
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("Expected output to contain %q, but it did not", expected)
+		}
+	}
+
+	// Validate formatting structure (headers then data)
+	if !strings.Contains(output, "Type") || !strings.Contains(output, "Name") ||
+		!strings.Contains(output, "Size") || !strings.Contains(output, "Modified") {
+		t.Errorf("Expected output to contain header columns")
+	}
+
+	// Check the timestamp format
+	expectedTimeStr := fixedTime.Format(time.RFC3339)
+	if !strings.Contains(output, expectedTimeStr) {
+		t.Errorf("Expected output to contain timestamp %q, but it did not", expectedTimeStr)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"bytes"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -10,10 +10,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"text/tabwriter"
 	"unicode/utf8"
 
 	"github.com/patrickdappollonio/http-server/internal/ctype"
+	"github.com/patrickdappollonio/http-server/internal/renderer"
 	isort "github.com/patrickdappollonio/http-server/internal/sort"
 	"github.com/saintfish/chardet"
 )
@@ -135,9 +135,6 @@ type FileInfo struct {
 }
 
 func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Request) {
-	// Get the output format from query parameters
-	outputFormat := r.URL.Query().Get("output")
-
 	// Append index.html or index.htm to the path and see if the index
 	// file exists, if so, return it instead
 	for _, index := range []string{"index.html", "index.htm"} {
@@ -204,25 +201,32 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 	}
 
 	// Handle different output formats
-	if outputFormat != "" {
-		switch strings.ToLower(outputFormat) {
-		case "json":
-			s.renderJSONListing(files, r.URL.Path, w)
-			return
-		case "terminal":
-			s.renderTerminalListing(files, r.URL.Path, w)
-			return
-		case "plain-list":
-			s.renderPlainListListing(files, w)
-			return
-		default:
-			// Return an error for unsupported output formats
-			s.printWarningf("unsupported output format requested: %s", outputFormat)
-			httpError(http.StatusBadRequest, w, "unsupported output format: %s (supported formats: json, terminal, plain-list)", outputFormat)
+	if outputFormat := r.URL.Query().Get("output"); outputFormat != "" {
+		// Get parent directory URL
+		parent := getParentURL(s.PathPrefix, r.URL.Path)
+
+		// Create renderer configuration
+		config := renderer.Config{
+			CurrentPath: r.URL.Path,
+			ParentPath:  parent,
+			Logger:      s.LogOutput,
+		}
+
+		// Render the directory listing
+		if err := renderer.Render(outputFormat, config, w, files); err != nil {
+			if errors.Is(err, renderer.UnsupportedFormatError{}) {
+				s.printWarningf("unsupported output format: %s", err)
+				httpError(http.StatusBadRequest, w, "unsupported output format: %q (supported formats: %s)",
+					outputFormat, renderer.GetSupportedFormatsString())
+				return
+			}
+
+			s.printWarningf("error rendering directory listing: %s", err)
+			httpError(http.StatusInternalServerError, w, "error rendering directory listing -- see application logs for more information")
 			return
 		}
+		return
 	}
-	// If no output format is specified, continue with HTML rendering
 
 	// Find if among the files there's a markdown readme
 	var markdownContent bytes.Buffer
@@ -257,95 +261,6 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 		httpError(http.StatusInternalServerError, w, "unable to render directory listing -- see application logs for more information")
 		return
 	}
-}
-
-// renderJSONListing renders a directory listing in JSON format
-func (s *Server) renderJSONListing(files []os.FileInfo, currentPath string, w http.ResponseWriter) {
-	parent := getParentURL(s.PathPrefix, currentPath)
-
-	fileList := make([]FileInfo, 0, len(files))
-
-	for _, file := range files {
-		filePath := filepath.Join(currentPath, file.Name())
-		if !strings.HasSuffix(filePath, "/") && file.IsDir() {
-			filePath += "/"
-		}
-
-		fileList = append(fileList, FileInfo{
-			Name:        file.Name(),
-			Size:        file.Size(),
-			IsDirectory: file.IsDir(),
-			ModTime:     file.ModTime().Format("2006-01-02 15:04:05"),
-			Path:        filePath,
-		})
-	}
-
-	response := map[string]interface{}{
-		"current_path": currentPath,
-		"parent_path":  parent,
-		"files":        fileList,
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		s.printWarningf("unable to render JSON directory listing: %s", err)
-		httpError(http.StatusInternalServerError, w, "unable to render JSON directory listing -- see application logs for more information")
-	}
-}
-
-// renderTerminalListing renders a directory listing in terminal-friendly format
-func (s *Server) renderTerminalListing(files []os.FileInfo, currentPath string, w http.ResponseWriter) {
-	parent := getParentURL(s.PathPrefix, currentPath)
-
-	var buf bytes.Buffer
-	tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
-
-	fmt.Fprintf(tw, "Current directory: %s\n", currentPath)
-	if parent != "" {
-		fmt.Fprintf(tw, "Parent directory: %s\n", parent)
-	}
-	fmt.Fprintf(tw, "\n")
-
-	// Write headers
-	fmt.Fprintf(tw, "Type\tName\tSize\tModified\n")
-	fmt.Fprintf(tw, "----\t----\t----\t--------\n")
-
-	// Write file data
-	for _, file := range files {
-		fileType := "FILE"
-		if file.IsDir() {
-			fileType = "DIR"
-		}
-
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\n",
-			fileType,
-			file.Name(),
-			file.Size(),
-			file.ModTime().Format("2006-01-02 15:04:05"),
-		)
-	}
-
-	tw.Flush()
-
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Write(buf.Bytes())
-}
-
-// renderPlainListListing renders a simple list of filenames with directories having trailing slashes
-func (s *Server) renderPlainListListing(files []os.FileInfo, w http.ResponseWriter) {
-	var output strings.Builder
-
-	for _, file := range files {
-		name := file.Name()
-		if file.IsDir() {
-			name += "/"
-		}
-		output.WriteString(name + "\n")
-	}
-
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.Write([]byte(output.String()))
 }
 
 // statusCodeHijacker is a response writer that captures the status code
@@ -447,11 +362,13 @@ func (s *Server) healthCheck(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("OK"))
 }
 
+// httpError writes an error message to the response writer.
 func httpError(statusCode int, w http.ResponseWriter, format string, args ...any) {
 	w.WriteHeader(statusCode)
 	fmt.Fprintf(w, format, args...)
 }
 
+// getParentURL returns the parent URL for the given location.
 func getParentURL(base, loc string) string {
 	if loc == base {
 		return ""


### PR DESCRIPTION
This PR enhances the directory listing functionality by adding support for alternative output formats that can be requested through query parameters. Until now, the server only provided HTML directory listings, but users often need machine-readable or simpler text-based formats for automation, scripting, or terminal use.

We've added three new output formats that users can request via the `output` query parameter. The JSON format (`?output=json`) returns a structured representation of the directory contents with detailed metadata about each file, making it ideal for programmatic access or web applications. For example, requesting `/documents/?output=json` would return a JSON object containing file sizes, modification times, and paths.

For terminal users, we've implemented a clean tabular format (`?output=terminal`) that displays file information in neatly aligned columns with headers. This makes it easy to scan directory contents in a command-line environment without the overhead of HTML. Requesting `/downloads/?output=terminal` would show a table with file types, names, sizes, and modification dates.

We've also added a minimal plain-list format (`?output=plain-list`) that simply outputs filenames with trailing slashes for directories. This format is perfect for simple parsing or when only names are needed. A request to `/configs/?output=plain-list` would return just the bare essentials - one filename per line.