### PR TITLE
Fix rendering all markdown by default.

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,11 +8,10 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"unicode/utf8"
-
-	"slices"
 
 	"github.com/patrickdappollonio/http-server/internal/ctype"
 	"github.com/patrickdappollonio/http-server/internal/fileutil"

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -83,15 +83,15 @@ func (s *Server) showOrRender(w http.ResponseWriter, r *http.Request) {
 	// If the path is not a directory, then it's a file, so we can render it,
 	// let's check first if it's a markdown file
 	if ext := strings.ToLower(filepath.Ext(currentPath)); ext == ".md" || ext == ".markdown" {
-		// Check if this is an index-like markdown file or if FullMarkdownRender is enabled
-		isIndexFile := false
-		filename := filepath.Base(currentPath)
-
-		if slices.Contains(allowedIndexFiles, filename) {
-			isIndexFile = true
+		// Check FullMarkdownRender first to avoid unnecessary filename extraction
+		if s.FullMarkdownRender {
+			s.serveMarkdown(currentPath, w, r)
+			return
 		}
 
-		if isIndexFile || s.FullMarkdownRender {
+		// Not rendering all markdown, check if this is an index-like file
+		filename := filepath.Base(currentPath)
+		if slices.Contains(allowedIndexFiles, filename) {
 			s.serveMarkdown(currentPath, w, r)
 			return
 		}


### PR DESCRIPTION
There's a flag that forces all markdown files to be rendered. Unfortunately since the last update, it seems every single markdown file is being rendered, not just the index-like files.

This PR dials that back to its original behaviour.