### PR TITLE
Refactor: Use os.Root for sandboxed file operations

### DIFF
--- a/app.go
+++ b/app.go
@@ -83,6 +83,14 @@ func run() error {
 			// Print some sane defaults and some information about the request
 			srv.PrintStartup()
 
+			// Create the root context for sandboxed file operations
+			rootCtx, err := os.OpenRoot(srv.Path)
+			if err != nil {
+				return fmt.Errorf("unable to create root context for path %q: %w", srv.Path, err)
+			}
+			srv.RootCtx = rootCtx
+			// *os.Root does not have a Close method, so no defer srv.Close() is needed here.
+
 			// Run the server
 			return srv.ListenAndServe()
 		},

--- a/app.go
+++ b/app.go
@@ -89,7 +89,6 @@ func run() error {
 				return fmt.Errorf("unable to create root context for path %q: %w", srv.Path, err)
 			}
 			srv.RootCtx = rootCtx
-			// *os.Root does not have a Close method, so no defer srv.Close() is needed here.
 
 			// Run the server
 			return srv.ListenAndServe()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -357,8 +357,6 @@ func (s *Server) serveFile(statusCode int, location string, w http.ResponseWrite
 	if err != nil && !errors.Is(err, io.EOF) {
 		s.printWarningf("error reading file %q (relative: %q) for content type detection: %s", location, relativePath, err)
 		http.Error(w, "error reading file", http.StatusInternalServerError)
-		s.printWarningf("error reading file %q (relative: %q) for content type detection: %s", location, relativePath, err)
-		http.Error(w, "error reading file", http.StatusInternalServerError)
 		return
 	}
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -215,7 +215,7 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 		if err != nil {
 			// When using fs.DirEntry, f.Name() is the base name. For full path for logging, we might need to reconstruct or log relative path.
 			s.printWarningf("unable to stat file %q in %q: %s", f.Name(), relativePath, err)
-			httpError(http.StatusInternalServerError, w, "unable to stat file -- see application logs for more information")
+			httpError(http.StatusInternalServerError, w, "unable to stat file %q -- see application logs for more information", f.Name())
 			return
 		}
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -183,13 +183,13 @@ func (s *Server) walk(requestedPath string, w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		// If the directory doesn't exist, render an appropriate message
 		if os.IsNotExist(err) {
-			s.printWarningf("attempted to access non-existent path via RootCtx.Open: %s (relative: %s)", requestedPath, relativePath)
+			s.printWarningf("attempted to access non-existent path %q (relative: %q) using sandboxed context: %s", requestedPath, relativePath, err)
 			httpError(http.StatusNotFound, w, "404 not found")
 			return
 		}
 
 		// Otherwise handle it generically speaking
-		s.printWarningf("unable to open directory via RootCtx.Open %q (relative: %s): %s", requestedPath, relativePath, err)
+		s.printWarningf("unable to open directory %q (relative: %q) using sandboxed context: %s", requestedPath, relativePath, err)
 		httpError(http.StatusInternalServerError, w, "unable to open directory -- see application logs for more information")
 		return
 	}
@@ -327,11 +327,11 @@ func (s *Server) serveFile(statusCode int, location string, w http.ResponseWrite
 	f, err := s.RootCtx.Open(relativePath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			s.printWarningf("file not found via RootCtx.Open %q (relative: %q): %s", location, relativePath, err)
+			s.printWarningf("file not found %q (relative: %q) using sandboxed context: %s", location, relativePath, err)
 			httpError(http.StatusNotFound, w, "404 not found")
 			return
 		}
-		s.printWarningf("error opening file via RootCtx.Open %q (relative: %q): %s", location, relativePath, err)
+		s.printWarningf("error opening file %q (relative: %q) using sandboxed context: %s", location, relativePath, err)
 		http.Error(w, "error opening file", http.StatusInternalServerError)
 		return
 	}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"embed"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"embed"         // Ensure embed is imported
-	"html/template" // Ensure html/template is imported for template.New
 )
 
 //go:embed templates/*
@@ -21,35 +21,27 @@ var testHandlerTemplates embed.FS
 func newTestServer(t *testing.T) (*Server, string) {
 	t.Helper()
 
-	// Create a temporary root directory for the server
 	tempRoot := t.TempDir()
 
-	// Create the root context for the server
 	rootCtx, err := os.OpenRoot(tempRoot)
 	if err != nil {
 		t.Fatalf("Failed to create root context for temp root directory %q: %v", tempRoot, err)
 	}
 
-	// Initialize templates (minimal setup to avoid nil pointer in handlers)
-	// In a real scenario, you might need a more complete template setup if testing rendering.
-	// For sandboxing tests, we mainly care that the handlers don't panic before file access.
-	tpl := template.New("test") // Provides a non-nil, empty template set.
+	tpl := template.New("test")
 	// If actual template parsing is needed in the future for these tests:
-	// tpl, err := template.ParseFS(testHandlerTemplates, "templates/*.tmpl") // Corrected path for embed.FS
+	// tpl, err := template.ParseFS(testHandlerTemplates, "templates/*.tmpl")
 	// if err != nil {
-	// t.Fatalf("Failed to parse test templates: %v", err)
+	// 	t.Fatalf("Failed to parse test templates: %v", err)
 	// }
 
 	s := &Server{
-		Path:       tempRoot,
-		RootCtx:    rootCtx, // Use RootCtx now
-		PathPrefix: "/",     // Default path prefix for simplicity
-		LogOutput:  io.Discard,
-		templates:  tpl, // Assign parsed templates
-		// Add other essential fields if handlers require them to be non-nil/non-zero
-		// For example, if markdown processing or other features are implicitly triggered.
-		// For now, keeping it minimal for file access tests.
-		DisableDirectoryList: false, // Ensure walk is tested
+		Path:                 tempRoot,
+		RootCtx:              rootCtx,
+		PathPrefix:           "/",
+		LogOutput:            io.Discard,
+		templates:            tpl,
+		DisableDirectoryList: false,
 	}
 
 	return s, tempRoot
@@ -58,24 +50,18 @@ func newTestServer(t *testing.T) (*Server, string) {
 func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
 	s, tempRoot := newTestServer(t)
 
-	// --- Setup Files ---
-	// File inside the root
 	publicFilePath := filepath.Join(tempRoot, "public.txt")
 	if err := os.WriteFile(publicFilePath, []byte("public content"), 0644); err != nil {
 		t.Fatalf("Failed to write public.txt: %v", err)
 	}
 
-	// File outside the root (in the parent of tempRoot)
-	// To get the parent of tempRoot, we go up one level from tempRoot.
 	parentOfTempRoot := filepath.Dir(tempRoot)
 	sensitiveFilePath := filepath.Join(parentOfTempRoot, "sensitive.txt")
 	if err := os.WriteFile(sensitiveFilePath, []byte("sensitive content"), 0644); err != nil {
 		t.Fatalf("Failed to write sensitive.txt: %v", err)
 	}
-	// Cleanup sensitive file manually as it's outside t.TempDir()
 	t.Cleanup(func() { os.Remove(sensitiveFilePath) })
 
-	// File inside a subdirectory of the root
 	subDirPath := filepath.Join(tempRoot, "subdir")
 	if err := os.Mkdir(subDirPath, 0755); err != nil {
 		t.Fatalf("Failed to create subdir: %v", err)
@@ -86,12 +72,11 @@ func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
 		t.Fatalf("Failed to write subfile.txt: %v", err)
 	}
 
-	// --- Test Cases ---
 	tests := []struct {
 		name           string
 		urlPath        string
 		expectedStatus int
-		expectedBody   string // Empty if not checking body or if expecting error
+		expectedBody   string
 	}{
 		{
 			name:           "access public file in root",
@@ -107,11 +92,8 @@ func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
 		},
 		{
 			name:           "attempt path traversal to sensitive file",
-			urlPath:        "/../sensitive.txt", // This path will be joined with s.Path by the handler logic
-			                                     // but filepath.Rel(s.Path, joinedPath) will be tricky.
-			                                     // The key is how os.OpenRoot(s.RootFD, relativePathToOpen) behaves.
-			                                     // If relativePathToOpen starts with "../", os.OpenRoot should prevent it.
-			expectedStatus: http.StatusNotFound, // Or potentially Bad Request, depending on how path cleaning occurs before OpenRoot
+			urlPath:        "/../sensitive.txt",
+			expectedStatus: http.StatusNotFound,
 		},
 		{
 			name:           "attempt path traversal from subdir to sensitive file",
@@ -132,8 +114,6 @@ func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// The URL path for NewRequest should be exactly what the user would type.
-			// s.showOrRender will internally join s.Path + r.URL.Path, then calculate relative path for OpenRoot.
 			req := httptest.NewRequest("GET", tc.urlPath, nil)
 			rr := httptest.NewRecorder()
 
@@ -149,7 +129,6 @@ func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
 					t.Errorf("Expected body %q, got %q", tc.expectedBody, body)
 				}
 			} else {
-				// For error cases like 404, ensure sensitive content wasn't leaked
 				if strings.Contains(rr.Body.String(), "sensitive content") {
 					t.Errorf("Sensitive content leaked in response body for %s: %s", tc.urlPath, rr.Body.String())
 				}
@@ -161,12 +140,9 @@ func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
 func TestWalk_OpenRoot_Sandboxing(t *testing.T) {
 	s, tempRoot := newTestServer(t)
 
-	// --- Setup Files & Directories ---
-	// File in root
 	if err := os.WriteFile(filepath.Join(tempRoot, "file_in_root.txt"), []byte("root file"), 0644); err != nil {
 		t.Fatalf("Failed to write file_in_root.txt: %v", err)
 	}
-	// Subdirectory in root
 	subDirPath := filepath.Join(tempRoot, "sub")
 	if err := os.Mkdir(subDirPath, 0755); err != nil {
 		t.Fatalf("Failed to create subdir 'sub': %v", err)
@@ -175,29 +151,25 @@ func TestWalk_OpenRoot_Sandboxing(t *testing.T) {
 		t.Fatalf("Failed to write file_in_sub.txt: %v", err)
 	}
 
-	// External directory (sibling to tempRoot, should not be accessible)
 	parentOfTempRoot := filepath.Dir(tempRoot)
 	externalDirPath := filepath.Join(parentOfTempRoot, "external_dir")
 	if err := os.Mkdir(externalDirPath, 0755); err != nil {
-		// If it already exists from a previous failed run, ignore. Otherwise, fail.
 		if !os.IsExist(err) {
 			t.Fatalf("Failed to create external_dir: %v", err)
 		}
 	} else {
-		// Only schedule cleanup if we created it
 		t.Cleanup(func() { os.RemoveAll(externalDirPath) })
 	}
 	if err := os.WriteFile(filepath.Join(externalDirPath, "external_file.txt"), []byte("external content"), 0644); err != nil {
 		t.Fatalf("Failed to write external_file.txt: %v", err)
 	}
 
-
 	tests := []struct {
-		name             string
-		urlPath          string // Note: For walk, paths should end with "/"
-		expectedStatus   int
-		mustContain      []string // Substrings that must be in the response body for success
-		mustNotContain   []string // Substrings that must NOT be in the response body
+		name           string
+		urlPath        string
+		expectedStatus int
+		mustContain    []string
+		mustNotContain []string
 	}{
 		{
 			name:           "list root directory",
@@ -213,11 +185,9 @@ func TestWalk_OpenRoot_Sandboxing(t *testing.T) {
 		},
 		{
 			name:           "attempt to list parent using traversal",
-			urlPath:        "/../", // This should resolve relative to s.Path, then be used by OpenRoot.
-			                         // Effectively asking OpenRoot to open "." on its existing FD if path becomes empty or ".".
-			                         // Or, if the logic makes it "../" for OpenRoot, it should be denied.
-			expectedStatus: http.StatusNotFound, // Or Bad Request. The crucial part is no listing of parent.
-			mustNotContain: []string{filepath.Base(tempRoot), "external_dir"}, // tempRoot's name, external_dir name
+			urlPath:        "/../",
+			expectedStatus: http.StatusNotFound,
+			mustNotContain: []string{filepath.Base(tempRoot), "external_dir"},
 		},
 		{
 			name:           "attempt to list external_dir using traversal",
@@ -256,25 +226,3 @@ func TestWalk_OpenRoot_Sandboxing(t *testing.T) {
 		})
 	}
 }
-
-// Minimalistic template parsing logic, similar to what's in server/template.go
-// but without all the functions if they are not strictly needed for handler execution
-// up to the point of file access.
-func parseTemplates(fsInstance assets.FsProvider) (*template.Template, error) {
-	entries, err := fsInstance.ReadDir("internal/server/templates")
-	if err != nil {
-		return nil, fmt.Errorf("failed to read dir: %w", err)
-	}
-
-	var templateFilePaths []string
-	for _, entry := range entries {
-		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".tmpl") {
-			templateFilePaths = append(templateFilePaths, "internal/server/templates/"+entry.Name())
-		}
-	}
-
-	if len(templateFilePaths) == 0 {
-		return nil, fmt.Errorf("no template files found")
-	}
-
-	// Using a simple name for the template collection for testing purposes

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -28,12 +28,11 @@ func newTestServer(t *testing.T) (*Server, string) {
 		t.Fatalf("Failed to create root context for temp root directory %q: %v", tempRoot, err)
 	}
 
-	tpl := template.New("test")
-	// If actual template parsing is needed in the future for these tests:
-	// tpl, err := template.ParseFS(testHandlerTemplates, "templates/*.tmpl")
-	// if err != nil {
-	// 	t.Fatalf("Failed to parse test templates: %v", err)
-	// }
+	// Initialize templates by parsing the actual template files.
+	tpl, err := template.ParseFS(testHandlerTemplates, "*.tmpl")
+	if err != nil {
+		t.Fatalf("Failed to parse test templates: %v", err)
+	}
 
 	s := &Server{
 		Path:                 tempRoot,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -9,9 +9,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/patrickdappollonio/http-server/internal/server/assets"
+	"embed"         // Ensure embed is imported
+	"html/template" // Ensure html/template is imported for template.New
 )
+
+//go:embed templates/*
+var testHandlerTemplates embed.FS
 
 // newTestServer creates a new server instance for testing, with a temporary root directory.
 // It also creates the RootCtx for the server using os.OpenRoot.
@@ -30,10 +33,12 @@ func newTestServer(t *testing.T) (*Server, string) {
 	// Initialize templates (minimal setup to avoid nil pointer in handlers)
 	// In a real scenario, you might need a more complete template setup if testing rendering.
 	// For sandboxing tests, we mainly care that the handlers don't panic before file access.
-	tpl, err := parseTemplates(assets.Assets)
-	if err != nil {
-		t.Fatalf("Failed to parse templates: %v", err)
-	}
+	tpl := template.New("test") // Provides a non-nil, empty template set.
+	// If actual template parsing is needed in the future for these tests:
+	// tpl, err := template.ParseFS(testHandlerTemplates, "templates/*.tmpl") // Corrected path for embed.FS
+	// if err != nil {
+	// t.Fatalf("Failed to parse test templates: %v", err)
+	// }
 
 	s := &Server{
 		Path:       tempRoot,
@@ -273,5 +278,3 @@ func parseTemplates(fsInstance assets.FsProvider) (*template.Template, error) {
 	}
 
 	// Using a simple name for the template collection for testing purposes
-	return template.New("test_templates").ParseFS(fsInstance, templateFilePaths...)
-}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/patrickdappollonio/http-server/internal/server/assets"
+)
+
+// newTestServer creates a new server instance for testing, with a temporary root directory.
+// It also creates the RootCtx for the server using os.OpenRoot.
+func newTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+
+	// Create a temporary root directory for the server
+	tempRoot := t.TempDir()
+
+	// Create the root context for the server
+	rootCtx, err := os.OpenRoot(tempRoot)
+	if err != nil {
+		t.Fatalf("Failed to create root context for temp root directory %q: %v", tempRoot, err)
+	}
+
+	// Initialize templates (minimal setup to avoid nil pointer in handlers)
+	// In a real scenario, you might need a more complete template setup if testing rendering.
+	// For sandboxing tests, we mainly care that the handlers don't panic before file access.
+	tpl, err := parseTemplates(assets.Assets)
+	if err != nil {
+		t.Fatalf("Failed to parse templates: %v", err)
+	}
+
+	s := &Server{
+		Path:       tempRoot,
+		RootCtx:    rootCtx, // Use RootCtx now
+		PathPrefix: "/",     // Default path prefix for simplicity
+		LogOutput:  io.Discard,
+		templates:  tpl, // Assign parsed templates
+		// Add other essential fields if handlers require them to be non-nil/non-zero
+		// For example, if markdown processing or other features are implicitly triggered.
+		// For now, keeping it minimal for file access tests.
+		DisableDirectoryList: false, // Ensure walk is tested
+	}
+
+	// *os.Root does not have a Close method, so no t.Cleanup for s.RootCtx.Close() is needed.
+	// The underlying file descriptor for the directory opened by os.OpenRoot is managed by the runtime
+	// and typically closed when the *os.Root object is garbage collected or the process exits.
+
+	return s, tempRoot
+}
+
+func TestServeFile_OpenRoot_Sandboxing(t *testing.T) {
+	s, tempRoot := newTestServer(t)
+
+	// --- Setup Files ---
+	// File inside the root
+	publicFilePath := filepath.Join(tempRoot, "public.txt")
+	if err := os.WriteFile(publicFilePath, []byte("public content"), 0644); err != nil {
+		t.Fatalf("Failed to write public.txt: %v", err)
+	}
+
+	// File outside the root (in the parent of tempRoot)
+	// To get the parent of tempRoot, we go up one level from tempRoot.
+	parentOfTempRoot := filepath.Dir(tempRoot)
+	sensitiveFilePath := filepath.Join(parentOfTempRoot, "sensitive.txt")
+	if err := os.WriteFile(sensitiveFilePath, []byte("sensitive content"), 0644); err != nil {
+		t.Fatalf("Failed to write sensitive.txt: %v", err)
+	}
+	// Cleanup sensitive file manually as it's outside t.TempDir()
+	t.Cleanup(func() { os.Remove(sensitiveFilePath) })
+
+	// File inside a subdirectory of the root
+	subDirPath := filepath.Join(tempRoot, "subdir")
+	if err := os.Mkdir(subDirPath, 0755); err != nil {
+		t.Fatalf("Failed to create subdir: %v", err)
+	}
+	subFileContent := "subdir content"
+	subFilePath := filepath.Join(subDirPath, "subfile.txt")
+	if err := os.WriteFile(subFilePath, []byte(subFileContent), 0644); err != nil {
+		t.Fatalf("Failed to write subfile.txt: %v", err)
+	}
+
+	// --- Test Cases ---
+	tests := []struct {
+		name           string
+		urlPath        string
+		expectedStatus int
+		expectedBody   string // Empty if not checking body or if expecting error
+	}{
+		{
+			name:           "access public file in root",
+			urlPath:        "/public.txt",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "public content",
+		},
+		{
+			name:           "access file in subdirectory",
+			urlPath:        "/subdir/subfile.txt",
+			expectedStatus: http.StatusOK,
+			expectedBody:   subFileContent,
+		},
+		{
+			name:           "attempt path traversal to sensitive file",
+			urlPath:        "/../sensitive.txt", // This path will be joined with s.Path by the handler logic
+			                                     // but filepath.Rel(s.Path, joinedPath) will be tricky.
+			                                     // The key is how os.OpenRoot(s.RootFD, relativePathToOpen) behaves.
+			                                     // If relativePathToOpen starts with "../", os.OpenRoot should prevent it.
+			expectedStatus: http.StatusNotFound, // Or potentially Bad Request, depending on how path cleaning occurs before OpenRoot
+		},
+		{
+			name:           "attempt path traversal from subdir to sensitive file",
+			urlPath:        "/subdir/../../sensitive.txt",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "access non-existent file in root",
+			urlPath:        "/nonexistent.txt",
+			expectedStatus: http.StatusNotFound,
+		},
+		{
+			name:           "access non-existent file in subdir",
+			urlPath:        "/subdir/nonexistent.txt",
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// The URL path for NewRequest should be exactly what the user would type.
+			// s.showOrRender will internally join s.Path + r.URL.Path, then calculate relative path for OpenRoot.
+			req := httptest.NewRequest("GET", tc.urlPath, nil)
+			rr := httptest.NewRecorder()
+
+			s.showOrRender(rr, req)
+
+			if rr.Code != tc.expectedStatus {
+				t.Errorf("Expected status %d, got %d. Body: %s", tc.expectedStatus, rr.Code, rr.Body.String())
+			}
+
+			if tc.expectedBody != "" {
+				body := strings.TrimSpace(rr.Body.String())
+				if body != tc.expectedBody {
+					t.Errorf("Expected body %q, got %q", tc.expectedBody, body)
+				}
+			} else {
+				// For error cases like 404, ensure sensitive content wasn't leaked
+				if strings.Contains(rr.Body.String(), "sensitive content") {
+					t.Errorf("Sensitive content leaked in response body for %s: %s", tc.urlPath, rr.Body.String())
+				}
+			}
+		})
+	}
+}
+
+func TestWalk_OpenRoot_Sandboxing(t *testing.T) {
+	s, tempRoot := newTestServer(t)
+
+	// --- Setup Files & Directories ---
+	// File in root
+	if err := os.WriteFile(filepath.Join(tempRoot, "file_in_root.txt"), []byte("root file"), 0644); err != nil {
+		t.Fatalf("Failed to write file_in_root.txt: %v", err)
+	}
+	// Subdirectory in root
+	subDirPath := filepath.Join(tempRoot, "sub")
+	if err := os.Mkdir(subDirPath, 0755); err != nil {
+		t.Fatalf("Failed to create subdir 'sub': %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDirPath, "file_in_sub.txt"), []byte("sub file"), 0644); err != nil {
+		t.Fatalf("Failed to write file_in_sub.txt: %v", err)
+	}
+
+	// External directory (sibling to tempRoot, should not be accessible)
+	parentOfTempRoot := filepath.Dir(tempRoot)
+	externalDirPath := filepath.Join(parentOfTempRoot, "external_dir")
+	if err := os.Mkdir(externalDirPath, 0755); err != nil {
+		// If it already exists from a previous failed run, ignore. Otherwise, fail.
+		if !os.IsExist(err) {
+			t.Fatalf("Failed to create external_dir: %v", err)
+		}
+	} else {
+		// Only schedule cleanup if we created it
+		t.Cleanup(func() { os.RemoveAll(externalDirPath) })
+	}
+	if err := os.WriteFile(filepath.Join(externalDirPath, "external_file.txt"), []byte("external content"), 0644); err != nil {
+		t.Fatalf("Failed to write external_file.txt: %v", err)
+	}
+
+
+	tests := []struct {
+		name             string
+		urlPath          string // Note: For walk, paths should end with "/"
+		expectedStatus   int
+		mustContain      []string // Substrings that must be in the response body for success
+		mustNotContain   []string // Substrings that must NOT be in the response body
+	}{
+		{
+			name:           "list root directory",
+			urlPath:        "/",
+			expectedStatus: http.StatusOK,
+			mustContain:    []string{"file_in_root.txt", "sub/"},
+		},
+		{
+			name:           "list subdirectory",
+			urlPath:        "/sub/",
+			expectedStatus: http.StatusOK,
+			mustContain:    []string{"file_in_sub.txt"},
+		},
+		{
+			name:           "attempt to list parent using traversal",
+			urlPath:        "/../", // This should resolve relative to s.Path, then be used by OpenRoot.
+			                         // Effectively asking OpenRoot to open "." on its existing FD if path becomes empty or ".".
+			                         // Or, if the logic makes it "../" for OpenRoot, it should be denied.
+			expectedStatus: http.StatusNotFound, // Or Bad Request. The crucial part is no listing of parent.
+			mustNotContain: []string{filepath.Base(tempRoot), "external_dir"}, // tempRoot's name, external_dir name
+		},
+		{
+			name:           "attempt to list external_dir using traversal",
+			urlPath:        fmt.Sprintf("/../%s/", filepath.Base(externalDirPath)),
+			expectedStatus: http.StatusNotFound,
+			mustNotContain: []string{"external_file.txt"},
+		},
+		{
+			name:           "list non-existent directory",
+			urlPath:        "/nonexistent_dir/",
+			expectedStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.urlPath, nil)
+			rr := httptest.NewRecorder()
+
+			s.showOrRender(rr, req)
+
+			if rr.Code != tc.expectedStatus {
+				t.Errorf("URL: %s - Expected status %d, got %d. Body: %s", tc.urlPath, tc.expectedStatus, rr.Code, rr.Body.String())
+			}
+
+			for _, substr := range tc.mustContain {
+				if !strings.Contains(rr.Body.String(), substr) {
+					t.Errorf("URL: %s - Expected body to contain %q, but it didn't. Body: %s", tc.urlPath, substr, rr.Body.String())
+				}
+			}
+			for _, substr := range tc.mustNotContain {
+				if strings.Contains(rr.Body.String(), substr) {
+					t.Errorf("URL: %s - Expected body NOT to contain %q, but it did. Body: %s", tc.urlPath, substr, rr.Body.String())
+				}
+			}
+		})
+	}
+}
+
+// Minimalistic template parsing logic, similar to what's in server/template.go
+// but without all the functions if they are not strictly needed for handler execution
+// up to the point of file access.
+func parseTemplates(fsInstance assets.FsProvider) (*template.Template, error) {
+	entries, err := fsInstance.ReadDir("internal/server/templates")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read dir: %w", err)
+	}
+
+	var templateFilePaths []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".tmpl") {
+			templateFilePaths = append(templateFilePaths, "internal/server/templates/"+entry.Name())
+		}
+	}
+
+	if len(templateFilePaths) == 0 {
+		return nil, fmt.Errorf("no template files found")
+	}
+	
+	// Using a simple name for the template collection for testing purposes
+	return template.New("test_templates").ParseFS(fsInstance, templateFilePaths...)
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -47,10 +47,6 @@ func newTestServer(t *testing.T) (*Server, string) {
 		DisableDirectoryList: false, // Ensure walk is tested
 	}
 
-	// *os.Root does not have a Close method, so no t.Cleanup for s.RootCtx.Close() is needed.
-	// The underlying file descriptor for the directory opened by os.OpenRoot is managed by the runtime
-	// and typically closed when the *os.Root object is garbage collected or the process exits.
-
 	return s, tempRoot
 }
 

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -271,7 +271,7 @@ func parseTemplates(fsInstance assets.FsProvider) (*template.Template, error) {
 	if len(templateFilePaths) == 0 {
 		return nil, fmt.Errorf("no template files found")
 	}
-	
+
 	// Using a simple name for the template collection for testing purposes
 	return template.New("test_templates").ParseFS(fsInstance, templateFilePaths...)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"html/template"
 	"io"
+	"os" // Ensure os package is imported
 	"path"
 	"strings"
 
@@ -71,7 +72,7 @@ type Server struct {
 	SkipForceDownloadFiles  []string
 
 	// Root context for sandboxed file operations
-	RootCtx *os.Root
+	RootCtx *os.Root // This line should now be valid
 }
 
 // IsBasicAuthEnabled returns true if the server has been configured with

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -69,6 +69,9 @@ type Server struct {
 	// Force download settings
 	ForceDownloadExtensions []string
 	SkipForceDownloadFiles  []string
+
+	// Root context for sandboxed file operations
+	RootCtx *os.Root
 }
 
 // IsBasicAuthEnabled returns true if the server has been configured with


### PR DESCRIPTION
This commit refactors the server's file system interactions to use the `os.OpenRoot(name string) (*os.Root, error)` function and the associated `(*os.Root).Open(relativePath string) (*os.File, error)` method. This aligns with modern Go sandboxing practices, ensuring that all file access is strictly contained within the server's configured root directory.

Key changes:
- The `Server` struct in `internal/server/server.go` now stores an `*os.Root` object (in the `RootCtx` field) instead of an `*os.File` descriptor for its root path.
- Server initialization in `app.go` has been updated to call `os.OpenRoot(serverPath)` to obtain the `*os.Root` context.
- The `Server.Close()` method related to the old file descriptor has been removed, as `*os.Root` itself does not require explicit closing.
- The `walk` and `serveFile` handlers in `internal/server/handlers.go` now use `s.RootCtx.Open(relativePath)` to open directories and files.
- Tests in `internal/server/handlers_test.go` have been updated to correctly initialize the server with the `*os.Root` context.

This change enhances the server's security by leveraging the built-in sandboxing capabilities provided by the `os.Root` type in Go 1.24, preventing directory traversal vulnerabilities more robustly.