### PR TITLE
Fix custom CSS path joining

### DIFF
--- a/internal/server/custom_css_test.go
+++ b/internal/server/custom_css_test.go
@@ -1,0 +1,46 @@
+package server
+
+import "testing"
+
+func TestGetCustomCSSURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		prefix    string
+		customCSS string
+		want      string
+	}{
+		{
+			name:      "no prefix relative path",
+			prefix:    "/",
+			customCSS: "style.css",
+			want:      "/style.css",
+		},
+		{
+			name:      "prefix relative path",
+			prefix:    "/blog/",
+			customCSS: "style.css",
+			want:      "/blog/style.css",
+		},
+		{
+			name:      "prefix absolute path",
+			prefix:    "/blog/",
+			customCSS: "/style.css",
+			want:      "/blog/style.css",
+		},
+		{
+			name:      "root absolute path",
+			prefix:    "/",
+			customCSS: "/style.css",
+			want:      "/style.css",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{PathPrefix: tt.prefix, CustomCSS: tt.customCSS}
+			if got := s.getCustomCSSURL(); got != tt.want {
+				t.Errorf("getCustomCSSURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,10 +89,10 @@ func (s *Server) getCustomCSSURL() string {
 		return ""
 	}
 
-	css := s.CustomCSS
+	css := strings.TrimPrefix(s.CustomCSS, "/")
 
 	if s.PathPrefix != "" {
-		css = path.Join(s.PathPrefix, s.CustomCSS)
+		css = path.Join(s.PathPrefix, css)
 	}
 
 	if !strings.HasPrefix(css, "/") {


### PR DESCRIPTION
- fix custom CSS URL generation when the configured path starts with '/'
- add regression tests for custom CSS path joining
