### PR TITLE
Fix CORS documentation grammar

### DIFF
--- a/docs/cors-requests.md
+++ b/docs/cors-requests.md
@@ -2,6 +2,6 @@
 
 `http-server` supports CORS, which means you can use it to serve files to other domains. This is done by setting the `Access-Control-Allow-Origin` header to `*`, which means any domain can access the files.
 
-The server also support `HEAD` requests, however, considering the `http-server` only supports `GET` request, they should be unnecessary for a full CORS experience since preflight requests are only made for non-`GET` requests only.
+The server also supports `HEAD` requests, however, considering the `http-server` only supports `GET` requests, they should be unnecessary for a full CORS experience since preflight requests are only made for non-`GET` requests only.
 
 CORS requests work both in file server mode as well as directory listing mode.


### PR DESCRIPTION
## Summary
- fix grammar about supported HEAD and GET requests in `cors-requests` docs

## Testing
- `go test ./...` *(fails: access denied while downloading module)*

------
https://chatgpt.com/codex/tasks/task_e_68488467546c8331aab5ad8f94fe3a32