### PR TITLE
Fix config file handling and add tests

### DIFF
--- a/app.go
+++ b/app.go
@@ -191,7 +191,8 @@ func bindCobraAndViper(rootCommand *cobra.Command) error {
 	if err := v.ReadInConfig(); err != nil {
 		// If the configuration file was not found, it's all good, we ignore
 		// the failure and proceed with the default settings
-		if f := (&viper.ConfigFileNotFoundError{}); errors.As(err, &f) {
+		var cfErr viper.ConfigFileNotFoundError
+		if !errors.As(err, &cfErr) {
 			return fmt.Errorf("unable to read configuration file: %w", err)
 		}
 	}

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestBindCobraAndViper_NoConfigFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("chdir to temp dir: %v", err)
+	}
+	defer os.Chdir(prev)
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("foo", false, "")
+
+	if err := bindCobraAndViper(cmd); err != nil {
+		t.Fatalf("bindCobraAndViper returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid returning an error when the config file is missing
- test bindCobraAndViper with no config file present

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68488b3fede883319b2f80d6be4d7025